### PR TITLE
test: make the committed_blocks test more strict

### DIFF
--- a/carnot/test_unhappy_path.py
+++ b/carnot/test_unhappy_path.py
@@ -259,6 +259,6 @@ class TestCarnotUnhappyPath(TestCase):
             root_votes = succeed(self, overlay, nodes, proposed_block)
             proposed_block = leader.propose_block(view, root_votes).payload
 
-        committed_blocks = [0, 1, 2, 3, 6, 9, 10, 11]
+        committed_blocks = {0, 1, 2, 3, 6, 9, 10, 11}
         for node in nodes.values():
-            self.assertEqual(committed_blocks, sorted([block.view for block in node.committed_blocks().values()]))
+            self.assertEqual(committed_blocks, {block.view for block in node.committed_blocks().values()})


### PR DESCRIPTION
We have been missing some committed blocks (9, 10 and 11) in the test.