### PR TITLE
Use package prefix to run unittests at the root dir

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,4 +16,4 @@ jobs:
       - name: Install dependencies
         run: pip install -r requirements.txt
       - name: Run tests
-        run: cd carnot && python -m unittest
+        run: python -m unittest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
         uses: actions/setup-python@v5
         with:
           # Semantic version range syntax or exact version of a Python version
-          python-version: '3.x'
+          python-version: '3.11'
       - name: Install dependencies
         run: pip install -r requirements.txt
       - name: Run tests

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: Set up Python 3.x
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           # Semantic version range syntax or exact version of a Python version
           python-version: '3.x'

--- a/carnot/beaconized_carnot.py
+++ b/carnot/beaconized_carnot.py
@@ -1,8 +1,8 @@
 from typing import Set
 
-from carnot import Carnot, Block, TimeoutQc, Vote, Event, Send, Quorum
-from beacon import *
-from overlay import EntropyOverlay
+from carnot.carnot import Carnot, Block, TimeoutQc, Vote, Event, Send, Quorum
+from carnot.beacon import *
+from carnot.overlay import EntropyOverlay
 
 @dataclass
 class BeaconizedBlock(Block):

--- a/carnot/overlay.py
+++ b/carnot/overlay.py
@@ -1,7 +1,7 @@
 import random
 from abc import abstractmethod
 from typing import Set, Optional, List, Self
-from carnot import Overlay, Id, Committee, View
+from carnot.carnot import Overlay, Id, Committee, View
 
 
 class EntropyOverlay(Overlay):

--- a/carnot/test_beacon_verification.py
+++ b/carnot/test_beacon_verification.py
@@ -1,7 +1,7 @@
 from typing import Tuple
 from unittest import TestCase
 
-from beacon import *
+from carnot.beacon import *
 from random import randint
 
 

--- a/carnot/test_beaconized_carnot.py
+++ b/carnot/test_beaconized_carnot.py
@@ -5,11 +5,11 @@ from itertools import chain
 
 from blspy import PrivateKey
 
-from carnot import Id, Carnot, Block, Overlay, Vote, StandardQc, NewView
-from beacon import generate_random_sk, RandomBeacon, NormalMode, RecoveryMode
-from beaconized_carnot import BeaconizedCarnot, BeaconizedBlock
-from overlay import FlatOverlay, EntropyOverlay
-from test_unhappy_path import parents_from_childs
+from carnot.carnot import Id, Carnot, Block, Overlay, Vote, StandardQc, NewView
+from carnot.beacon import generate_random_sk, RandomBeacon, NormalMode, RecoveryMode
+from carnot.beaconized_carnot import BeaconizedCarnot, BeaconizedBlock
+from carnot.overlay import FlatOverlay, EntropyOverlay
+from carnot.test_unhappy_path import parents_from_childs
 
 
 def gen_node(sk: PrivateKey, overlay: Overlay, entropy: bytes = b""):

--- a/carnot/test_happy_path.py
+++ b/carnot/test_happy_path.py
@@ -1,4 +1,4 @@
-from carnot import *
+from carnot.carnot import *
 from unittest import TestCase
 
 

--- a/carnot/test_tree_overlay.py
+++ b/carnot/test_tree_overlay.py
@@ -1,6 +1,6 @@
 from unittest import TestCase
 
-from tree_overlay import CarnotOverlay, CarnotTree
+from carnot.tree_overlay import CarnotOverlay, CarnotTree
 
 
 class TestCarnotTree(TestCase):

--- a/carnot/test_unhappy_path.py
+++ b/carnot/test_unhappy_path.py
@@ -1,4 +1,4 @@
-from carnot import *
+from carnot.carnot import *
 from unittest import TestCase
 from itertools import chain
 

--- a/carnot/tree_overlay.py
+++ b/carnot/tree_overlay.py
@@ -1,8 +1,8 @@
 import itertools
 from hashlib import blake2b
 from typing import List, Dict, Tuple, Set, Optional, Self
-from carnot import Id, Committee
-from overlay import EntropyOverlay
+from carnot.carnot import Id, Committee
+from carnot.overlay import EntropyOverlay
 import random
 
 


### PR DESCRIPTION
When importing packages that we wrote, use a prefix `carnot.`, so that we can run unit tests at the project root using `python -m unittest`.
This would be useful for other packages other than carnot to be added, such as `mixnet`.