### PR TITLE
Use Python 3.12 and install setuptools

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
         uses: actions/setup-python@v5
         with:
           # Semantic version range syntax or exact version of a Python version
-          python-version: '3.11'
+          python-version: '3.x'
       - name: Install dependencies
         run: pip install -r requirements.txt
       - name: Run tests

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,7 @@
-blspy==1.0.16
+blspy==2.0.2
 cffi==1.16.0
 cryptography==41.0.7
-numpy==1.26.2
+numpy==1.26.3
 pycparser==2.21
-scipy==1.10.1
+scipy==1.11.4
+setuptools==69.0.3


### PR DESCRIPTION
Closes #43 

Since Python 3.12, `setuptools` is not bundled, which is required to build `blspy`.
https://github.com/python/cpython/issues/95299
To resolve this, I added `setuptools` to the `requirements.txt`.
Also, I had to bump some packages to make it compile on Python 3.12.