### PR TITLE
Mixnet: Refactor with asyncio

### DIFF
--- a/mixnet/test_client.py
+++ b/mixnet/test_client.py
@@ -1,54 +1,54 @@
-import queue
+import asyncio
 from datetime import datetime
 from typing import Tuple
-from unittest import TestCase
+from unittest import IsolatedAsyncioTestCase
 
 import numpy
-import timeout_decorator
 from cryptography.hazmat.primitives.asymmetric.x25519 import X25519PrivateKey
 
 from mixnet.bls import generate_bls
-from mixnet.client import MixClientRunner
+from mixnet.client import mixclient_emitter
 from mixnet.mixnet import Mixnet, MixnetTopology
 from mixnet.node import MixNode, PacketQueue
 from mixnet.packet import PacketBuilder
 from mixnet.poisson import poisson_mean_interval_sec
 from mixnet.utils import random_bytes
+from mixnet.test_utils import with_test_timeout
 
 
-class TestMixClientRunner(TestCase):
-    @timeout_decorator.timeout(180)
-    def test_mixclient_runner_emission_rate(self):
+class TestMixClient(IsolatedAsyncioTestCase):
+    @with_test_timeout(100)
+    async def test_mixclient_emitter(self):
         mixnet, topology = self.init()
-        real_packet_queue: PacketQueue = queue.Queue()
-        outbound_socket: PacketQueue = queue.Queue()
+        real_packet_queue: PacketQueue = asyncio.Queue()
+        outbound_socket: PacketQueue = asyncio.Queue()
 
         emission_rate_per_min = 30
         redundancy = 3
-        client = MixClientRunner(
-            mixnet,
-            topology,
-            emission_rate_per_min,
-            redundancy,
-            real_packet_queue,
-            outbound_socket,
+        _ = asyncio.create_task(
+            mixclient_emitter(
+                mixnet,
+                topology,
+                emission_rate_per_min,
+                redundancy,
+                real_packet_queue,
+                outbound_socket,
+            )
         )
-        client.daemon = True
-        client.start()
 
         # Create packets. At least two packets are expected to be generated from a 3500-byte msg
         builder = PacketBuilder.real(random_bytes(3500), mixnet, topology)
         # Schedule two packets to the mix client without any interval
         packet, route = builder.next()
-        real_packet_queue.put((route[0].addr, packet))
+        await real_packet_queue.put((route[0].addr, packet))
         packet, route = builder.next()
-        real_packet_queue.put((route[0].addr, packet))
+        await real_packet_queue.put((route[0].addr, packet))
 
         # Calculate intervals between packet emissions from the mix client
         intervals = []
         ts = datetime.now()
         for _ in range(30):
-            _ = outbound_socket.get()
+            _ = await outbound_socket.get()
             now = datetime.now()
             intervals.append((now - ts).total_seconds())
             ts = now

--- a/mixnet/test_node.py
+++ b/mixnet/test_node.py
@@ -1,12 +1,9 @@
-import queue
-import threading
-import time
+import asyncio
 from datetime import datetime
 from typing import Tuple
-from unittest import TestCase
+from unittest import IsolatedAsyncioTestCase
 
 import numpy
-import timeout_decorator
 from cryptography.hazmat.primitives.asymmetric.x25519 import X25519PrivateKey
 from pysphinx.sphinx import SphinxPacket
 
@@ -15,12 +12,13 @@ from mixnet.mixnet import Mixnet, MixnetTopology
 from mixnet.node import MixNode, NodeAddress, PacketPayloadQueue, PacketQueue
 from mixnet.packet import PacketBuilder
 from mixnet.poisson import poisson_interval_sec, poisson_mean_interval_sec
+from mixnet.test_utils import with_test_timeout
 from mixnet.utils import random_bytes
 
 
-class TestMixNodeRunner(TestCase):
-    @timeout_decorator.timeout(180)
-    def test_mixnode_runner_emission_rate(self):
+class TestMixNodeRunner(IsolatedAsyncioTestCase):
+    @with_test_timeout(180)
+    async def test_mixnode_runner_emission_rate(self):
         """
         Test if MixNodeRunner works as a M/M/inf queue.
 
@@ -29,40 +27,39 @@ class TestMixNodeRunner(TestCase):
         the rate of outputs should be `lambda`.
         """
         mixnet, topology = self.init()
-        inbound_socket: PacketQueue = queue.Queue()
-        outbound_socket: PacketPayloadQueue = queue.Queue()
+        inbound_socket: PacketQueue = asyncio.Queue()
+        outbound_socket: PacketPayloadQueue = asyncio.Queue()
 
         packet, route = PacketBuilder.real(b"msg", mixnet, topology).next()
 
         delay_rate_per_min = 30  # mu (= 2s delay on average)
         # Start only the first mix node for testing
-        runner = route[0].start(delay_rate_per_min, inbound_socket, outbound_socket)
+        runner, _ = await route[0].start(
+            delay_rate_per_min, inbound_socket, outbound_socket
+        )
 
         # Send packets to the first mix node in a Poisson distribution
         packet_count = 100
         emission_rate_per_min = 120  # lambda (= 2msg/sec)
-        sender = threading.Thread(
-            target=self.send_packets,
-            args=(
+        _ = asyncio.create_task(
+            self.send_packets(
                 inbound_socket,
                 packet,
                 route[0].addr,
                 packet_count,
                 emission_rate_per_min,
-            ),
+            )
         )
-        sender.daemon = True
-        sender.start()
 
         # Calculate intervals between outputs and gather num_jobs in the first mix node.
         intervals = []
         num_jobs = []
         ts = datetime.now()
         for _ in range(packet_count):
-            _ = outbound_socket.get()
+            _ = await outbound_socket.get()
             now = datetime.now()
             intervals.append((now - ts).total_seconds())
-            num_jobs.append(runner.num_jobs())
+            num_jobs.append(await runner.num_jobs())
             ts = now
         # Remove the first interval that would be much larger than other intervals,
         # because of the delay in mix node.
@@ -87,7 +84,7 @@ class TestMixNodeRunner(TestCase):
         )
 
     @staticmethod
-    def send_packets(
+    async def send_packets(
         inbound_socket: PacketQueue,
         packet: SphinxPacket,
         node_addr: NodeAddress,
@@ -95,8 +92,9 @@ class TestMixNodeRunner(TestCase):
         rate_per_min: int,
     ):
         for _ in range(cnt):
-            time.sleep(poisson_interval_sec(rate_per_min))
-            inbound_socket.put((node_addr, packet))
+            # Since the task is not heavy, just sleep for seconds instead of using emission_notifier
+            await asyncio.sleep(poisson_interval_sec(rate_per_min))
+            await inbound_socket.put((node_addr, packet))
 
     @staticmethod
     def init() -> Tuple[Mixnet, MixnetTopology]:

--- a/mixnet/test_utils.py
+++ b/mixnet/test_utils.py
@@ -1,0 +1,12 @@
+import asyncio
+
+
+def with_test_timeout(t):
+    def wrapper(coroutine):
+        async def run(*args, **kwargs):
+            async with asyncio.timeout(t):
+                return await coroutine(*args, **kwargs)
+
+        return run
+
+    return wrapper


### PR DESCRIPTION
As previously discussed in https://github.com/logos-co/nomos-specs/pull/49#discussion_r1453154141, https://github.com/logos-co/nomos-specs/pull/50#discussion_r1457568051, https://github.com/logos-co/nomos-specs/pull/51#discussion_r1457710293, and https://github.com/logos-co/nomos-specs/pull/51#discussion_r1457573764, I refactored mixnet specs with using [asyncio](https://docs.python.org/3/library/asyncio.html). Now, it's more readable and simpler than the previous code that had verbose time calculations and sleeps.