### PR TITLE
Mixnet: topology update

### DIFF
--- a/mixnet/client.py
+++ b/mixnet/client.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import asyncio
 
-from mixnet.mixnet import Mixnet, MixnetTopology
+from mixnet.mixnet import Mixnet
 from mixnet.node import PacketQueue
 from mixnet.packet import PacketBuilder
 from mixnet.poisson import poisson_interval_sec
@@ -10,7 +10,6 @@ from mixnet.poisson import poisson_interval_sec
 
 async def mixclient_emitter(
     mixnet: Mixnet,
-    topology: MixnetTopology,
     emission_rate_per_min: int,  # Poisson rate parameter: lambda in the spec
     redundancy: int,  # b in the spec
     real_packet_queue: PacketQueue,
@@ -38,7 +37,6 @@ async def mixclient_emitter(
         try:
             await emit(
                 mixnet,
-                topology,
                 redundancy,
                 real_packet_queue,
                 redundant_real_packet_queue,
@@ -51,7 +49,6 @@ async def mixclient_emitter(
 
 async def emit(
     mixnet: Mixnet,
-    topology: MixnetTopology,
     redundancy: int,  # b in the spec
     real_packet_queue: PacketQueue,
     redundant_real_packet_queue: PacketQueue,
@@ -69,7 +66,7 @@ async def emit(
             redundant_real_packet_queue.put_nowait((addr, packet))
             await outbound_socket.put((addr, packet))
 
-    packet, route = PacketBuilder.drop_cover(b"drop cover", mixnet, topology).next()
+    packet, route = PacketBuilder.drop_cover(b"drop cover", mixnet).next()
     await outbound_socket.put((route[0].addr, packet))
 
 

--- a/mixnet/mixnet.py
+++ b/mixnet/mixnet.py
@@ -10,14 +10,12 @@ from mixnet.node import MixNode
 class Mixnet:
     __topology: MixnetTopology | None = None
 
-    @property
-    def topology(self) -> MixnetTopology:
+    def get_topology(self) -> MixnetTopology:
         if self.__topology is None:
             raise RuntimeError("topology is not set yet")
         return self.__topology
 
-    @topology.setter
-    def topology(self, topology: MixnetTopology) -> None:
+    def set_topology(self, topology: MixnetTopology) -> None:
         """
         Replace the old topology with the new topology received, and start establishing new network connections in background.
 

--- a/mixnet/mixnet.py
+++ b/mixnet/mixnet.py
@@ -19,15 +19,14 @@ class Mixnet:
         Here in the spec, this method has been simplified as a setter, assuming the single-thread test environment.
         """
         self.topology = topology
-        self.establish_connections(topology)
+        self.establish_connections()
 
     def get_topology(self) -> MixnetTopology:
         if self.topology is None:
             raise RuntimeError("topology is not set yet")
         return self.topology
 
-    @staticmethod
-    def establish_connections(_: MixnetTopology) -> None:
+    def establish_connections(self) -> None:
         """
         Establish network connections in advance based on the topology received.
 

--- a/mixnet/mixnet.py
+++ b/mixnet/mixnet.py
@@ -4,44 +4,59 @@ import random
 from dataclasses import dataclass
 from typing import List
 
-from mixnet.fisheryates import FisherYates
 from mixnet.node import MixNode
 
 
 @dataclass
 class Mixnet:
-    mix_nodes: List[MixNode]
+    topology: MixnetTopology | None = None
 
-    # Build a new topology deterministically using an entropy.
-    # The entropy is expected to be injected from outside.
-    #
-    # TODO: Implement constructing a new topology in advance to minimize the topology transition time.
-    #       https://www.notion.so/Mixnet-Specification-807b624444a54a4b88afa1cc80e100c2?pvs=4#9a7f6089e210454bb11fe1c10fceff68
-    def build_topology(
-        self,
-        entropy: bytes,
-        n_layers: int,
-        n_nodes_per_layer: int,
-    ) -> MixnetTopology:
-        num_nodes = n_nodes_per_layer * n_layers
-        assert num_nodes < len(self.mix_nodes)
+    def set_topology(self, topology: MixnetTopology) -> None:
+        """
+        Replace the old topology with the new topology received, and start establishing new network connections in background.
 
-        shuffled = FisherYates.shuffle(self.mix_nodes, entropy)
-        sampled = shuffled[:num_nodes]
-        layers = []
-        for l in range(n_layers):
-            start = l * n_nodes_per_layer
-            layer = sampled[start : start + n_nodes_per_layer]
-            layers.append(layer)
-        return MixnetTopology(layers)
+        In real implementations, this method should be a long-running task, accepting topologies periodically.
+        Here in the spec, this method has been simplified as a setter, assuming the single-thread test environment.
+        """
+        self.topology = topology
+        self.establish_connections(topology)
 
-    def choose_mixnode(self) -> MixNode:
-        return random.choice(self.mix_nodes)
+    def get_topology(self) -> MixnetTopology:
+        if self.topology is None:
+            raise RuntimeError("topology is not set yet")
+        return self.topology
+
+    @staticmethod
+    def establish_connections(_: MixnetTopology) -> None:
+        """
+        Establish network connections in advance based on the topology received.
+
+        This is just a preparation to forward subsequent packets as quickly as possible,
+        but this is not a strict requirement.
+
+        In real implementations, this should be a background task.
+        """
+        pass
 
 
 @dataclass
 class MixnetTopology:
+    # In production, this can be a 1-D array, which is accessible by indexes.
+    # Here, we use a 2-D array for readability.
     layers: List[List[MixNode]]
 
     def generate_route(self) -> list[MixNode]:
         return [random.choice(layer) for layer in self.layers]
+
+    def choose_mix_destionation(self) -> MixNode:
+        all_mixnodes = [mixnode for layer in self.layers for mixnode in layer]
+        return random.choice(all_mixnodes)
+
+
+@dataclass
+class MixnetTopologySize:
+    num_layers: int
+    num_mixnodes_per_layer: int
+
+    def num_total_mixnodes(self) -> int:
+        return self.num_layers * self.num_mixnodes_per_layer

--- a/mixnet/mixnet.py
+++ b/mixnet/mixnet.py
@@ -43,12 +43,22 @@ class MixnetTopology:
     # Here, we use a 2-D array for readability.
     layers: List[List[MixNode]]
 
-    def generate_route(self) -> list[MixNode]:
-        return [random.choice(layer) for layer in self.layers]
+    def generate_route(self, mix_destination: MixNode) -> list[MixNode]:
+        """
+        Generate a mix route for a Sphinx packet.
+        The pre-selected mix_destination is used as a last mix node in the route,
+        so that associated packets can be merged together into a original message.
+        """
+        route = [random.choice(layer) for layer in self.layers[:-1]]
+        route.append(mix_destination)
+        return route
 
-    def choose_mix_destionation(self) -> MixNode:
-        all_mixnodes = [mixnode for layer in self.layers for mixnode in layer]
-        return random.choice(all_mixnodes)
+    def choose_mix_destination(self) -> MixNode:
+        """
+        Choose a mix node from the last mix layer as a mix destination
+        that will reconstruct a message from Sphinx packets.
+        """
+        return random.choice(self.layers[-1])
 
 
 @dataclass

--- a/mixnet/mixnet.py
+++ b/mixnet/mixnet.py
@@ -7,26 +7,27 @@ from typing import List
 from mixnet.node import MixNode
 
 
-@dataclass
 class Mixnet:
-    topology: MixnetTopology | None = None
+    __topology: MixnetTopology | None = None
 
-    def set_topology(self, topology: MixnetTopology) -> None:
+    @property
+    def topology(self) -> MixnetTopology:
+        if self.__topology is None:
+            raise RuntimeError("topology is not set yet")
+        return self.__topology
+
+    @topology.setter
+    def topology(self, topology: MixnetTopology) -> None:
         """
         Replace the old topology with the new topology received, and start establishing new network connections in background.
 
         In real implementations, this method should be a long-running task, accepting topologies periodically.
         Here in the spec, this method has been simplified as a setter, assuming the single-thread test environment.
         """
-        self.topology = topology
-        self.establish_connections()
+        self.__topology = topology
+        self.__establish_connections()
 
-    def get_topology(self) -> MixnetTopology:
-        if self.topology is None:
-            raise RuntimeError("topology is not set yet")
-        return self.topology
-
-    def establish_connections(self) -> None:
+    def __establish_connections(self) -> None:
         """
         Establish network connections in advance based on the topology received.
 

--- a/mixnet/packet.py
+++ b/mixnet/packet.py
@@ -29,7 +29,7 @@ class PacketBuilder:
         message: bytes,
         mixnet: Mixnet,
     ):
-        topology = mixnet.topology
+        topology = mixnet.get_topology()
         destination = topology.choose_mix_destionation()
 
         msg_with_flag = flag.bytes() + message

--- a/mixnet/packet.py
+++ b/mixnet/packet.py
@@ -30,7 +30,7 @@ class PacketBuilder:
         mixnet: Mixnet,
     ):
         topology = mixnet.get_topology()
-        destination = topology.choose_mix_destionation()
+        destination = topology.choose_mix_destination()
 
         msg_with_flag = flag.bytes() + message
         # NOTE: We don't encrypt msg_with_flag for destination.
@@ -39,7 +39,7 @@ class PacketBuilder:
 
         packets_and_routes = []
         for fragment in fragment_set.fragments:
-            route = topology.generate_route()
+            route = topology.generate_route(destination)
             packet = SphinxPacket.build(
                 fragment.bytes(),
                 [mixnode.sphinx_node() for mixnode in route],

--- a/mixnet/packet.py
+++ b/mixnet/packet.py
@@ -9,7 +9,7 @@ from typing import Dict, Iterator, List, Self, Tuple, TypeAlias
 from pysphinx.payload import Payload
 from pysphinx.sphinx import SphinxPacket
 
-from mixnet.mixnet import Mixnet, MixnetTopology, MixNode
+from mixnet.mixnet import Mixnet, MixNode
 
 
 class MessageFlag(Enum):
@@ -29,7 +29,7 @@ class PacketBuilder:
         message: bytes,
         mixnet: Mixnet,
     ):
-        topology = mixnet.get_topology()
+        topology = mixnet.topology
         destination = topology.choose_mix_destionation()
 
         msg_with_flag = flag.bytes() + message

--- a/mixnet/packet.py
+++ b/mixnet/packet.py
@@ -28,9 +28,9 @@ class PacketBuilder:
         flag: MessageFlag,
         message: bytes,
         mixnet: Mixnet,
-        topology: MixnetTopology,
     ):
-        destination = mixnet.choose_mixnode()
+        topology = mixnet.get_topology()
+        destination = topology.choose_mix_destionation()
 
         msg_with_flag = flag.bytes() + message
         # NOTE: We don't encrypt msg_with_flag for destination.
@@ -50,14 +50,12 @@ class PacketBuilder:
         self.iter = iter(packets_and_routes)
 
     @classmethod
-    def real(cls, message: bytes, mixnet: Mixnet, topology: MixnetTopology) -> Self:
-        return cls(MessageFlag.MESSAGE_FLAG_REAL, message, mixnet, topology)
+    def real(cls, message: bytes, mixnet: Mixnet) -> Self:
+        return cls(MessageFlag.MESSAGE_FLAG_REAL, message, mixnet)
 
     @classmethod
-    def drop_cover(
-        cls, message: bytes, mixnet: Mixnet, topology: MixnetTopology
-    ) -> Self:
-        return cls(MessageFlag.MESSAGE_FLAG_DROP_COVER, message, mixnet, topology)
+    def drop_cover(cls, message: bytes, mixnet: Mixnet) -> Self:
+        return cls(MessageFlag.MESSAGE_FLAG_DROP_COVER, message, mixnet)
 
     def next(self) -> Tuple[SphinxPacket, List[MixNode]]:
         return next(self.iter)

--- a/mixnet/robustness.py
+++ b/mixnet/robustness.py
@@ -44,7 +44,7 @@ class Robustness:
         Here in the spec, this method has been simplified as a setter, assuming the single-thread test environment.
         """
         topology = self.build_topology(entropy)
-        self.mixnet.topology = topology
+        self.mixnet.set_topology(topology)
 
     def build_topology(self, entropy: bytes) -> MixnetTopology:
         """

--- a/mixnet/robustness.py
+++ b/mixnet/robustness.py
@@ -1,0 +1,63 @@
+from __future__ import annotations
+
+from typing import List
+
+from mixnet.fisheryates import FisherYates
+from mixnet.mixnet import (
+    Mixnet,
+    MixnetTopology,
+    MixnetTopologySize,
+)
+from mixnet.node import MixNode
+
+
+class Robustness:
+    """
+    A robustness layer is placed on top of a mixnet layer and a consensus layer,
+    to separate their responsibilities and minimize dependencies between them.
+
+    For v1, the role of robustness layer is building a new mixnet topology
+    and injecting it to the mixnet layer,
+    whenever a new entropy is received from the consensus layer.
+    A static list of nodes is used for building topologies deterministically.
+    This can be changed in later versions.
+
+    In later versions, the robustness layer will have more responsibilities.
+    """
+
+    def __init__(
+        self,
+        mixnode_candidates: List[MixNode],
+        mixnet_topology_size: MixnetTopologySize,
+        mixnet: Mixnet,
+    ) -> None:
+        assert mixnet_topology_size.num_total_mixnodes() <= len(mixnode_candidates)
+        self.mixnode_candidates = mixnode_candidates
+        self.mixnet_topology_size = mixnet_topology_size
+        self.mixnet = mixnet
+
+    def set_entropy(self, entropy: bytes) -> None:
+        """
+        Given a entropy received, build a new topology and send it to mixnet.
+
+        In real implementations, this method should be a long-running task, consuming entropy periodically.
+        Here in the spec, this method has been simplified as a setter, assuming the single-thread test environment.
+        """
+        topology = self.build_topology(entropy)
+        self.mixnet.set_topology(topology)
+
+    def build_topology(self, entropy: bytes) -> MixnetTopology:
+        """
+        Build a new topology deterministically using an entropy and a given set of candidates.
+        """
+        shuffled = FisherYates.shuffle(self.mixnode_candidates, entropy)
+        sampled = shuffled[: self.mixnet_topology_size.num_total_mixnodes()]
+
+        layers = []
+        for layer_id in range(self.mixnet_topology_size.num_layers):
+            start = layer_id * self.mixnet_topology_size.num_mixnodes_per_layer
+            layer = sampled[
+                start : start + self.mixnet_topology_size.num_mixnodes_per_layer
+            ]
+            layers.append(layer)
+        return MixnetTopology(layers)

--- a/mixnet/robustness.py
+++ b/mixnet/robustness.py
@@ -44,7 +44,7 @@ class Robustness:
         Here in the spec, this method has been simplified as a setter, assuming the single-thread test environment.
         """
         topology = self.build_topology(entropy)
-        self.mixnet.set_topology(topology)
+        self.mixnet.topology = topology
 
     def build_topology(self, entropy: bytes) -> MixnetTopology:
         """

--- a/mixnet/test_mixnet.py
+++ b/mixnet/test_mixnet.py
@@ -32,9 +32,9 @@ class TestMixnet(IsolatedAsyncioTestCase):
     def test_topology_from_robustness(self):
         mixnet, robustness = self.init()
 
-        topology1 = mixnet.topology
+        topology1 = mixnet.get_topology()
 
         robustness.set_entropy(b"new entropy")
-        topology2 = mixnet.topology
+        topology2 = mixnet.get_topology()
 
         self.assertNotEqual(topology1, topology2)

--- a/mixnet/test_packet.py
+++ b/mixnet/test_packet.py
@@ -43,7 +43,7 @@ class TestPacket(TestMixnet):
         )
 
     def test_cover_packet(self):
-        mixnet, topology = self.init()
+        mixnet, _ = self.init()
 
         msg = b"cover"
         builder = PacketBuilder.drop_cover(msg, mixnet)

--- a/mixnet/test_robustness.py
+++ b/mixnet/test_robustness.py
@@ -1,5 +1,4 @@
-from typing import Tuple
-from unittest import IsolatedAsyncioTestCase
+from unittest import TestCase
 
 from cryptography.hazmat.primitives.asymmetric.x25519 import X25519PrivateKey
 
@@ -9,10 +8,8 @@ from mixnet.robustness import Robustness
 from mixnet.utils import random_bytes
 
 
-class TestMixnet(IsolatedAsyncioTestCase):
-    @staticmethod
-    def init() -> Tuple[Mixnet, Robustness]:
-        mixnet = Mixnet()
+class TestRobustness(TestCase):
+    def test_build_topology(self):
         robustness = Robustness(
             [
                 MixNode(
@@ -23,18 +20,14 @@ class TestMixnet(IsolatedAsyncioTestCase):
                 for _ in range(12)
             ],
             MixnetTopologySize(3, 3),
-            mixnet,
+            Mixnet(),
         )
-        robustness.set_entropy(b"entropy")
 
-        return (mixnet, robustness)
-
-    def test_topology_from_robustness(self):
-        mixnet, robustness = self.init()
-
-        topology1 = mixnet.topology
-
-        robustness.set_entropy(b"new entropy")
-        topology2 = mixnet.topology
-
-        self.assertNotEqual(topology1, topology2)
+        topology = robustness.build_topology(b"entropy")
+        self.assertEqual(
+            len(topology.layers), robustness.mixnet_topology_size.num_layers
+        )
+        for layer in topology.layers:
+            self.assertEqual(
+                len(layer), robustness.mixnet_topology_size.num_mixnodes_per_layer
+            )


### PR DESCRIPTION
This is a new PR replacing the previous PR #51 closed.

This PR describes a [deterministic topology update](https://www.notion.so/Mixnet-Specification-807b624444a54a4b88afa1cc80e100c2?pvs=4#af141ade3e8147ec900cf3599953f4da) by introducing a "robustness layer" between a consensus layer and a mixnet layer. For details of design rationales, please see the spec in Notion that I linked above.