### PR TITLE
QUESTION: Use `LeaderProof.commitment` for `LedgerState.commitments_spend`

### DIFF
--- a/cryptarchia/cryptarchia.py
+++ b/cryptarchia/cryptarchia.py
@@ -260,7 +260,7 @@ class LedgerState:
         self.nonce = h.digest()
         self.block = block.id()
         self.nullifiers.add(block.leader_proof.nullifier)
-        self.commitments_spend.add(block.leader_proof.evolved_commitment)
+        self.commitments_spend.add(block.leader_proof.commitment)
         self.commitments_lead.add(block.leader_proof.evolved_commitment)
 
 
@@ -281,7 +281,7 @@ class EpochState:
         #
         # This verification is checking that first condition.
         #
-        # NOTE: `ledger_state.commitments_spend` is a super-set of `ledger_state.commitments_lead`
+        # NOTE: `ledger_state.commitments_spend` is a subset of `ledger_state.commitments_lead`
 
         return self.stake_distribution_snapshot.verify_eligible_to_spend(commitment)
 


### PR DESCRIPTION
This is just a question to understand the Cryptarchia spec correctly. This might be a dumb question since my understanding of Crypsinous is low. 

It seems that `block.leader_proof.evolved_commitment` is added to both `LedgerState.commitments_spend` and `LedgerState.commitments_lead` list. I would like to ask if this is the intended behavior, just to check my understanding. If so, those two lists are going to always the same, then I'm curious why we need to maintain both. I went through the entire spec but couldn't find the reason why we need to maintain both. 
It seems that the `commitments_spend` is used to check if a coin is eligible to lead based on the epoch state, and the `commitments_lead` is used to check the same thing based on the ledger state of the parent block. Then, I guess two lists have the same role.

Or, I'd like to ask whether the `block.leader_proof.commitment` (instead of `evolved_commitment`) should be added to the `LedgerState.commitments_spend`, like a change in this PR.

Please correct me if I'm wrong. Thank you!