### PR TITLE
Leader VRF uses coin nonce as well as sk

### DIFF
--- a/cryptarchia/cryptarchia.py
+++ b/cryptarchia/cryptarchia.py
@@ -70,6 +70,9 @@ class Slot:
     def epoch(self, config: Config) -> Epoch:
         return Epoch(self.absolute_slot // config.epoch_length)
 
+    def encode(self) -> bytes:
+        return int.to_bytes(self.absolute_slot, length=8, byteorder="big")
+
     def __eq__(self, other):
         return self.absolute_slot == other.absolute_slot
 
@@ -171,7 +174,7 @@ class BlockHeader:
         h.update(self.content_id)
 
         # slot
-        h.update(int.to_bytes(self.slot.absolute_slot, length=8, byteorder="big"))
+        h.update(self.slot.encode())
 
         # parent
         assert len(self.parent) == 32
@@ -256,7 +259,7 @@ class LedgerState:
         h.update("epoch-nonce".encode(encoding="utf-8"))
         h.update(self.nonce)
         h.update(block.leader_proof.nullifier)
-        h.update(block.slot.absolute_slot.to_bytes(8, byteorder="big"))
+        h.update(block.slot.encode())
 
         self.nonce = h.digest()
         self.block = block.id()
@@ -446,7 +449,7 @@ class MOCK_LEADER_VRF:
         h = sha256()
         h.update(int.to_bytes(sk, length=32, byteorder="big"))
         h.update(nonce)
-        h.update(int.to_bytes(slot.absolute_slot, length=8))
+        h.update(slot.encode())
         return int.from_bytes(h.digest())
 
     @classmethod

--- a/cryptarchia/cryptarchia.py
+++ b/cryptarchia/cryptarchia.py
@@ -88,7 +88,7 @@ class Coin:
         return self.sk
 
     def evolve(self) -> "Coin":
-        sk_bytes = int.to_bytes(self.sk, length=32, byteorder="little")
+        sk_bytes = int.to_bytes(self.sk, length=32, byteorder="big")
 
         h = blake2b(digest_size=32)
         h.update(b"coin-evolve")
@@ -100,8 +100,8 @@ class Coin:
 
     def commitment(self) -> Id:
         # TODO: mocked until CL is understood
-        pk_bytes = int.to_bytes(self.pk, length=32, byteorder="little")
-        value_bytes = int.to_bytes(self.value, length=32, byteorder="little")
+        pk_bytes = int.to_bytes(self.pk, length=32, byteorder="big")
+        value_bytes = int.to_bytes(self.value, length=32, byteorder="big")
 
         h = sha256()
         h.update(b"coin-commitment")
@@ -112,8 +112,8 @@ class Coin:
 
     def nullifier(self) -> Id:
         # TODO: mocked until CL is understood
-        pk_bytes = int.to_bytes(self.pk, length=32, byteorder="little")
-        value_bytes = int.to_bytes(self.value, length=32, byteorder="little")
+        pk_bytes = int.to_bytes(self.pk, length=32, byteorder="big")
+        value_bytes = int.to_bytes(self.value, length=32, byteorder="big")
 
         h = sha256()
         h.update(b"coin-nullifier")
@@ -442,11 +442,11 @@ class MOCK_LEADER_VRF:
     ORDER = 2**256
 
     @classmethod
-    def vrf(cls, sk: int, nonce: bytes, slot: int) -> int:
+    def vrf(cls, sk: int, nonce: bytes, slot: Slot) -> int:
         h = sha256()
-        h.update(int.to_bytes(sk, length=32))
+        h.update(int.to_bytes(sk, length=32, byteorder="big"))
         h.update(nonce)
-        h.update(int.to_bytes(slot, length=16))  # 64bit slots
+        h.update(int.to_bytes(slot.absolute_slot, length=8))
         return int.from_bytes(h.digest())
 
     @classmethod

--- a/cryptarchia/test_leader.py
+++ b/cryptarchia/test_leader.py
@@ -2,7 +2,16 @@ from unittest import TestCase
 
 import numpy as np
 
-from .cryptarchia import Leader, Config, EpochState, LedgerState, Coin, phi, TimeConfig
+from .cryptarchia import (
+    Leader,
+    Config,
+    EpochState,
+    LedgerState,
+    Coin,
+    phi,
+    TimeConfig,
+    Slot,
+)
 
 
 class TestLeader(TestCase):
@@ -35,7 +44,10 @@ class TestLeader(TestCase):
 
         # After N slots, the measured leader rate should be within the interval `p +- margin_of_error` with high probabiltiy
         leader_rate = (
-            sum(l.try_prove_slot_leader(epoch, slot) is not None for slot in range(N))
+            sum(
+                l.try_prove_slot_leader(epoch, Slot(slot)) is not None
+                for slot in range(N)
+            )
             / N
         )
         assert (


### PR DESCRIPTION
<img width="903" alt="Screenshot 2024-02-07 at 4 57 29 PM" src="https://github.com/logos-co/nomos-specs/assets/1832378/2bcea02e-5452-4878-af28-431c7233ebf9">

y is derived from "LEAD"||epoch_nonce||slot||coin_sk||coin_nonce


Also in this PR, standardize encoding to big-endian