### PR TITLE
Arkworks dependency utility script

### DIFF
--- a/install-arkworksbls-arch64-osx.sh
+++ b/install-arkworksbls-arch64-osx.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 pip install maturin
-git clone git@github.com:crate-crypto/py-arkworks-bls12381.git
+git clone --depth 1 --branch v0.3.4 git@github.com:crate-crypto/py-arkworks-bls12381.git
 cd py-arkworks-bls12381
 maturin develop
 cd ..

--- a/install-arkworksbls-arch64-osx.sh
+++ b/install-arkworksbls-arch64-osx.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+
+pip install maturin
+git clone git@github.com:crate-crypto/py-arkworks-bls12381.git
+cd py-arkworks-bls12381
+maturin develop
+cd ..
+rm -rf py-arkworks-bls12381


### PR DESCRIPTION
pip installs the x64 precompiled version of the arks dependancy library. Not working on macos using mX chipsets. This helps dealing with that manually