### PR TITLE
cryptarchia: Update epoch stabilization schedule to 334 (from 433)

### DIFF
--- a/cryptarchia/cryptarchia.py
+++ b/cryptarchia/cryptarchia.py
@@ -55,7 +55,7 @@ class Config:
 
     @property
     def s(self):
-        return self.base_period_length * self.epoch_period_nonce_stabilization
+        return self.base_period_length * 3
 
     def replace(self, **kwarg) -> "Config":
         return replace(self, **kwarg)

--- a/cryptarchia/cryptarchia.py
+++ b/cryptarchia/cryptarchia.py
@@ -29,32 +29,33 @@ class TimeConfig:
 class Config:
     k: int  # The depth of a block before it is considered immutable.
     active_slot_coeff: float  # 'f', the rate of occupied slots
+
+    # The stake distribution is always taken at the beginning of the previous epoch.
+    # This parameters controls how many slots to wait for it to be stabilized
+    # The value is computed as epoch_stake_distribution_stabilization * int(floor(k / f))
+    epoch_stake_distribution_stabilization: int
+    # This parameter controls how many slots we wait after the stake distribution
+    # snapshot has stabilized to take the nonce snapshot.
+    epoch_period_nonce_buffer: int
+    # This parameter controls how many slots we wait for the nonce snapshot to be considered
+    # stabilized
+    epoch_period_nonce_stabilization: int
+
     time: TimeConfig
 
-    @property
-    def epoch_stake_distribution_stabilization(self) -> int:
-        """
-        The stake distribution is always taken at the beginning of the previous epoch.
-        This parameters controls how many slots to wait for it to be stabilized
-        The value is computed as epoch_stake_distribution_stabilization * int(floor(k / f))
-        """
-        return 3
-
-    @property
-    def epoch_period_nonce_buffer(self) -> int:
-        """
-        This parameter controls how many slots we wait after the stake distribution
-        snapshot has stabilized to take the nonce snapshot.
-        """
-        return 3
-
-    @property
-    def epoch_period_nonce_stabilization(self) -> int:
-        """
-        This parameter controls how many slots we wait for the nonce snapshot to be considered
-        stabilized
-        """
-        return 4
+    @staticmethod
+    def cryptarchia_v0_0_1() -> "Config":
+        return Config(
+            k=2160,
+            active_slot_coeff=0.05,
+            epoch_stake_distribution_stabilization=3,
+            epoch_period_nonce_buffer=3,
+            epoch_period_nonce_stabilization=4,
+            time=TimeConfig(
+                slot_duration=1,
+                chain_start_time=0,
+            ),
+        )
 
     @property
     def base_period_length(self) -> int:

--- a/cryptarchia/cryptarchia.py
+++ b/cryptarchia/cryptarchia.py
@@ -448,6 +448,9 @@ class Follower:
         else:
             return self.genesis_state.block
 
+    def tip_state(self) -> LedgerState:
+        return self.ledger_state[self.tip_id]
+
     def state_at_slot_beginning(self, chain: Chain, slot: Slot) -> LedgerState:
         for block in reversed(chain.blocks):
             if block.slot < slot:

--- a/cryptarchia/cryptarchia.py
+++ b/cryptarchia/cryptarchia.py
@@ -27,19 +27,34 @@ class TimeConfig:
 
 @dataclass
 class Config:
-    k: int
+    k: int  # The depth of a block before it is considered immutable.
     active_slot_coeff: float  # 'f', the rate of occupied slots
-    # The stake distribution is always taken at the beginning of the previous epoch.
-    # This parameters controls how many slots to wait for it to be stabilized
-    # The value is computed as epoch_stake_distribution_stabilization * int(floor(k / f))
-    epoch_stake_distribution_stabilization: int
-    # This parameter controls how many slots we wait after the stake distribution
-    # snapshot has stabilized to take the nonce snapshot.
-    epoch_period_nonce_buffer: int
-    # This parameter controls how many slots we wait for the nonce snapshot to be considered
-    # stabilized
-    epoch_period_nonce_stabilization: int
     time: TimeConfig
+
+    @property
+    def epoch_stake_distribution_stabilization(self) -> int:
+        """
+        The stake distribution is always taken at the beginning of the previous epoch.
+        This parameters controls how many slots to wait for it to be stabilized
+        The value is computed as epoch_stake_distribution_stabilization * int(floor(k / f))
+        """
+        return 3
+
+    @property
+    def epoch_period_nonce_buffer(self) -> int:
+        """
+        This parameter controls how many slots we wait after the stake distribution
+        snapshot has stabilized to take the nonce snapshot.
+        """
+        return 3
+
+    @property
+    def epoch_period_nonce_stabilization(self) -> int:
+        """
+        This parameter controls how many slots we wait for the nonce snapshot to be considered
+        stabilized
+        """
+        return 4
 
     @property
     def base_period_length(self) -> int:
@@ -55,6 +70,10 @@ class Config:
 
     @property
     def s(self):
+        """
+        The Security Paramater. This paramter controls how many slots one must wait before we
+        have high confidence that k blocks have been produced.
+        """
         return self.base_period_length * 3
 
     def replace(self, **kwarg) -> "Config":

--- a/cryptarchia/cryptarchia.py
+++ b/cryptarchia/cryptarchia.py
@@ -6,7 +6,7 @@ from itertools import chain
 import functools
 
 # Please note this is still a work in progress
-from dataclasses import dataclass, field
+from dataclasses import dataclass, field, replace
 
 Id: TypeAlias = bytes
 
@@ -56,6 +56,9 @@ class Config:
     @property
     def s(self):
         return self.base_period_length * self.epoch_period_nonce_stabilization
+
+    def replace(self, **kwarg) -> "Config":
+        return replace(self, **kwarg)
 
 
 # An absolute unique indentifier of a slot, counting incrementally from 0

--- a/cryptarchia/cryptarchia.py
+++ b/cryptarchia/cryptarchia.py
@@ -452,7 +452,7 @@ class Follower:
             return self.genesis_state.block
 
     def tip_state(self) -> LedgerState:
-        return self.ledger_state[self.tip_id]
+        return self.ledger_state[self.tip_id()]
 
     def state_at_slot_beginning(self, chain: Chain, slot: Slot) -> LedgerState:
         for block in reversed(chain.blocks):

--- a/cryptarchia/test_common.py
+++ b/cryptarchia/test_common.py
@@ -10,3 +10,19 @@ def mk_config() -> Config:
         epoch_period_nonce_stabilization=4,
         time=TimeConfig(slot_duration=1, chain_start_time=0),
     )
+
+
+def mk_block(
+    parent: Id, slot: int, coin: Coin, content=bytes(32), orphaned_proofs=[]
+) -> BlockHeader:
+    assert len(parent) == 32
+    from hashlib import sha256
+
+    return BlockHeader(
+        slot=Slot(slot),
+        parent=parent,
+        content_size=len(content),
+        content_id=sha256(content).digest(),
+        leader_proof=MockLeaderProof.new(coin, Slot(slot), parent=parent),
+        orphaned_proofs=orphaned_proofs,
+    )

--- a/cryptarchia/test_common.py
+++ b/cryptarchia/test_common.py
@@ -3,7 +3,7 @@ from .cryptarchia import Config, TimeConfig
 
 def mk_config() -> Config:
     return Config(
-        k=2,
+        k=1,
         active_slot_coeff=1,
         epoch_stake_distribution_stabilization=3,
         epoch_period_nonce_buffer=3,

--- a/cryptarchia/test_common.py
+++ b/cryptarchia/test_common.py
@@ -48,18 +48,11 @@ def mk_block(
     )
 
 
-def mk_chain(
-    base_state: LedgerState, length: int, coin: Coin
-) -> tuple[list[BlockHeader], Coin]:
+def mk_chain(parent, coin: Coin, slots: list[int]) -> tuple[list[BlockHeader], Coin]:
     chain = []
-    parent = base_state.block
-    for i in range(length):
-        chain.append(
-            mk_block(
-                parent=parent,
-                slot=base_state.slot.absolute_slot + i,
-                coin=coin,
-            )
-        )
+    for s in slots:
+        block = mk_block(parent=parent, slot=s, coin=coin)
+        chain.append(block)
+        parent = block.id()
         coin = coin.evolve()
     return chain, coin

--- a/cryptarchia/test_common.py
+++ b/cryptarchia/test_common.py
@@ -11,10 +11,9 @@ from .cryptarchia import (
 
 
 def mk_config() -> Config:
-    return Config(
+    return Config.cryptarchia_v0_0_1().replace(
         k=1,
-        active_slot_coeff=1,
-        time=TimeConfig(slot_duration=1, chain_start_time=0),
+        active_slot_coeff=1.0,
     )
 
 

--- a/cryptarchia/test_common.py
+++ b/cryptarchia/test_common.py
@@ -1,4 +1,13 @@
-from .cryptarchia import Config, TimeConfig
+from .cryptarchia import (
+    Config,
+    TimeConfig,
+    Id,
+    Slot,
+    Coin,
+    BlockHeader,
+    LedgerState,
+    MockLeaderProof,
+)
 
 
 def mk_config() -> Config:
@@ -9,6 +18,17 @@ def mk_config() -> Config:
         epoch_period_nonce_buffer=3,
         epoch_period_nonce_stabilization=4,
         time=TimeConfig(slot_duration=1, chain_start_time=0),
+    )
+
+
+def mk_genesis_state(initial_stake_distribution: list[Coin]) -> LedgerState:
+    return LedgerState(
+        block=bytes(32),
+        nonce=bytes(32),
+        total_stake=sum(c.value for c in initial_stake_distribution),
+        commitments_spend={c.commitment() for c in initial_stake_distribution},
+        commitments_lead={c.commitment() for c in initial_stake_distribution},
+        nullifiers=set(),
     )
 
 
@@ -26,3 +46,20 @@ def mk_block(
         leader_proof=MockLeaderProof.new(coin, Slot(slot), parent=parent),
         orphaned_proofs=orphaned_proofs,
     )
+
+
+def mk_chain(
+    base_state: LedgerState, length: int, coin: Coin
+) -> tuple[list[BlockHeader], Coin]:
+    chain = []
+    parent = base_state.block
+    for i in range(length):
+        chain.append(
+            mk_block(
+                parent=parent,
+                slot=base_state.slot.absolute_slot + i,
+                coin=coin,
+            )
+        )
+        coin = coin.evolve()
+    return chain, coin

--- a/cryptarchia/test_common.py
+++ b/cryptarchia/test_common.py
@@ -1,0 +1,12 @@
+from .cryptarchia import Config, TimeConfig
+
+
+def mk_config() -> Config:
+    return Config(
+        k=2,
+        active_slot_coeff=1,
+        epoch_stake_distribution_stabilization=3,
+        epoch_period_nonce_buffer=3,
+        epoch_period_nonce_stabilization=4,
+        time=TimeConfig(slot_duration=1, chain_start_time=0),
+    )

--- a/cryptarchia/test_common.py
+++ b/cryptarchia/test_common.py
@@ -14,9 +14,6 @@ def mk_config() -> Config:
     return Config(
         k=1,
         active_slot_coeff=1,
-        epoch_stake_distribution_stabilization=3,
-        epoch_period_nonce_buffer=3,
-        epoch_period_nonce_stabilization=4,
         time=TimeConfig(slot_duration=1, chain_start_time=0),
     )
 

--- a/cryptarchia/test_fork_choice.py
+++ b/cryptarchia/test_fork_choice.py
@@ -14,6 +14,8 @@ from cryptarchia.cryptarchia import (
     Coin,
 )
 
+from .test_common import mk_chain
+
 
 def make_block(parent_id: Id, slot: Slot, content: bytes) -> BlockHeader:
     assert len(parent_id) == 32
@@ -32,48 +34,37 @@ def make_block(parent_id: Id, slot: Slot, content: bytes) -> BlockHeader:
 class TestLeader(TestCase):
     def test_fork_choice_long_sparse_chain(self):
         # The longest chain is not dense after the fork
-        common = [make_block(bytes(32), Slot(i), bytes(i)) for i in range(1, 50)]
-        long_chain = deepcopy(common)
-        short_chain = deepcopy(common)
+        short_coin, long_coin = Coin(sk=0, value=100), Coin(sk=1, value=100)
+        common, long_coin = mk_chain(parent=bytes(32), coin=long_coin, slots=range(50))
 
-        for slot in range(50, 100):
-            # make arbitrary ids for the different chain so that the blocks appear to be different
-            long_content = f"{slot}-long".encode()
-            short_content = f"{slot}-short".encode()
-            if slot % 2 == 0:
-                long_chain.append(make_block(bytes(32), Slot(slot), long_content))
-            short_chain.append(make_block(bytes(32), Slot(slot), short_content))
-        # add more blocks to the long chain
-        for slot in range(100, 200):
-            long_content = f"{slot}-long".encode()
-            long_chain.append(make_block(bytes(32), Slot(slot), long_content))
+        long_chain_sparse_ext, long_coin = mk_chain(
+            parent=common[-1].id(), coin=long_coin, slots=range(50, 100, 2)
+        )
+
+        short_chain_dense_ext, _ = mk_chain(
+            parent=common[-1].id(), coin=short_coin, slots=range(50, 100)
+        )
+
+        # add more blocks to the long chain to ensure the long chain is indeed longer
+        long_chain_further_ext, _ = mk_chain(
+            parent=long_chain_sparse_ext[-1].id(), coin=long_coin, slots=range(100, 126)
+        )
+
+        long_chain = deepcopy(common) + long_chain_sparse_ext + long_chain_further_ext
+        short_chain = deepcopy(common) + short_chain_dense_ext
         assert len(long_chain) > len(short_chain)
+
         # by setting a low k we trigger the density choice rule
         k = 1
         s = 50
+
         short_chain = Chain(short_chain, genesis=bytes(32))
         long_chain = Chain(long_chain, genesis=bytes(32))
-        assert (
-            maxvalid_bg(
-                short_chain,
-                [long_chain],
-                k,
-                s,
-            )
-            == short_chain
-        )
+        assert maxvalid_bg(short_chain, [long_chain], k, s) == short_chain
 
         # However, if we set k to the fork length, it will be accepted
         k = long_chain.length()
-        assert (
-            maxvalid_bg(
-                short_chain,
-                [long_chain],
-                k,
-                s,
-            )
-            == long_chain
-        )
+        assert maxvalid_bg(short_chain, [long_chain], k, s) == long_chain
 
     def test_fork_choice_long_dense_chain(self):
         # The longest chain is also the densest after the fork

--- a/cryptarchia/test_fork_choice.py
+++ b/cryptarchia/test_fork_choice.py
@@ -17,20 +17,6 @@ from cryptarchia.cryptarchia import (
 from .test_common import mk_chain
 
 
-def make_block(parent_id: Id, slot: Slot, content: bytes) -> BlockHeader:
-    assert len(parent_id) == 32
-    content_id = hashlib.sha256(content).digest()
-    return BlockHeader(
-        parent=parent_id,
-        content_size=1,
-        slot=slot,
-        content_id=content_id,
-        leader_proof=MockLeaderProof.new(
-            Coin(sk=0, value=10), slot=slot, parent=parent_id
-        ),
-    )
-
-
 class TestLeader(TestCase):
     def test_fork_choice_long_sparse_chain(self):
         # The longest chain is not dense after the fork
@@ -68,26 +54,23 @@ class TestLeader(TestCase):
 
     def test_fork_choice_long_dense_chain(self):
         # The longest chain is also the densest after the fork
-        common = [make_block(bytes(32), Slot(i), bytes(i)) for i in range(1, 50)]
-        long_chain = deepcopy(common)
-        short_chain = deepcopy(common)
-        for slot in range(50, 100):
-            # make arbitrary ids for the different chain so that the blocks appear to be different
-            long_content = f"{slot}-long".encode()
-            short_content = f"{slot}-short".encode()
-            long_chain.append(make_block(bytes(32), Slot(slot), long_content))
-            if slot % 2 == 0:
-                short_chain.append(make_block(bytes(32), Slot(slot), short_content))
+        short_coin, long_coin = Coin(sk=0, value=100), Coin(sk=1, value=100)
+        common, long_coin = mk_chain(
+            parent=bytes(32), coin=long_coin, slots=range(1, 50)
+        )
+
+        long_chain_dense_ext, _ = mk_chain(
+            parent=common[-1].id(), coin=long_coin, slots=range(50, 100)
+        )
+        short_chain_sparse_ext, _ = mk_chain(
+            parent=common[-1].id(), coin=short_coin, slots=range(50, 100, 2)
+        )
+
+        long_chain = deepcopy(common) + long_chain_dense_ext
+        short_chain = deepcopy(common) + short_chain_sparse_ext
+
         k = 1
         s = 50
         short_chain = Chain(short_chain, genesis=bytes(32))
         long_chain = Chain(long_chain, genesis=bytes(32))
-        assert (
-            maxvalid_bg(
-                short_chain,
-                [long_chain],
-                k,
-                s,
-            )
-            == long_chain
-        )
+        assert maxvalid_bg(short_chain, [long_chain], k, s) == long_chain

--- a/cryptarchia/test_fork_choice.py
+++ b/cryptarchia/test_fork_choice.py
@@ -17,7 +17,7 @@ from cryptarchia.cryptarchia import (
 from .test_common import mk_chain
 
 
-class TestLeader(TestCase):
+class TestForkChoice(TestCase):
     def test_fork_choice_long_sparse_chain(self):
         # The longest chain is not dense after the fork
         short_coin, long_coin = Coin(sk=0, value=100), Coin(sk=1, value=100)

--- a/cryptarchia/test_leader.py
+++ b/cryptarchia/test_leader.py
@@ -27,9 +27,9 @@ class TestLeader(TestCase):
         config = Config(
             k=10,
             active_slot_coeff=f,
-            epoch_stake_distribution_stabilization=4,
+            epoch_stake_distribution_stabilization=3,
             epoch_period_nonce_buffer=3,
-            epoch_period_nonce_stabilization=3,
+            epoch_period_nonce_stabilization=4,
             time=TimeConfig(slot_duration=1, chain_start_time=0),
         )
         l = Leader(config=config, coin=Coin(sk=0, value=10))

--- a/cryptarchia/test_leader.py
+++ b/cryptarchia/test_leader.py
@@ -38,7 +38,8 @@ class TestLeader(TestCase):
         Z = 3  # we want 3 std from the mean to be within the margin of error
         N = int((Z * std / margin_of_error) ** 2)
 
-        # After N slots, the measured leader rate should be within the interval `p +- margin_of_error` with high probabiltiy
+        # After N slots, the measured leader rate should be within the
+        # interval `p +- margin_of_error` with high probabiltiy
         leader_rate = (
             sum(
                 l.try_prove_slot_leader(epoch, Slot(slot), bytes(32)) is not None

--- a/cryptarchia/test_leader.py
+++ b/cryptarchia/test_leader.py
@@ -12,6 +12,7 @@ from .cryptarchia import (
     TimeConfig,
     Slot,
 )
+from .test_common import mk_config
 
 
 class TestLeader(TestCase):
@@ -24,15 +25,10 @@ class TestLeader(TestCase):
         )
 
         f = 0.05
-        config = Config(
-            k=10,
-            active_slot_coeff=f,
-            epoch_stake_distribution_stabilization=3,
-            epoch_period_nonce_buffer=3,
-            epoch_period_nonce_stabilization=4,
-            time=TimeConfig(slot_duration=1, chain_start_time=0),
+        l = Leader(
+            config=mk_config().replace(active_slot_coeff=f),
+            coin=Coin(sk=0, value=10),
         )
-        l = Leader(config=config, coin=Coin(sk=0, value=10))
 
         # We'll use the Margin of Error equation to decide how many samples we need.
         # https://en.wikipedia.org/wiki/Margin_of_error

--- a/cryptarchia/test_ledger_state_update.py
+++ b/cryptarchia/test_ledger_state_update.py
@@ -14,18 +14,7 @@ from .cryptarchia import (
     Id,
 )
 
-from .test_common import mk_config, mk_block
-
-
-def mk_genesis_state(initial_stake_distribution: list[Coin]) -> LedgerState:
-    return LedgerState(
-        block=bytes(32),
-        nonce=bytes(32),
-        total_stake=sum(c.value for c in initial_stake_distribution),
-        commitments_spend={c.commitment() for c in initial_stake_distribution},
-        commitments_lead={c.commitment() for c in initial_stake_distribution},
-        nullifiers=set(),
-    )
+from .test_common import mk_config, mk_block, mk_genesis_state
 
 
 class TestLedgerStateUpdate(TestCase):

--- a/cryptarchia/test_ledger_state_update.py
+++ b/cryptarchia/test_ledger_state_update.py
@@ -85,9 +85,7 @@ class TestLedgerStateUpdate(TestCase):
 
         follower.on_block(block_1)
         assert follower.tip_id() == block_1.id()
-        assert not follower.ledger_state[block_1.id()].verify_unspent(
-            coin_1.nullifier()
-        )
+        assert not follower.tip_state().verify_unspent(coin_1.nullifier())
 
         # 3) then sees block 2, but sticks with block_1 as the tip
 
@@ -103,7 +101,7 @@ class TestLedgerStateUpdate(TestCase):
         assert follower.tip_id() == block_3.id()
 
         # and the original coin_1 should now be removed from the spent pool
-        assert follower.ledger_state[block_3.id()].verify_unspent(coin_1.nullifier())
+        assert follower.tip_state().verify_unspent(coin_1.nullifier())
 
     def test_epoch_transition(self):
         leader_coins = [Coin(sk=i, value=100) for i in range(4)]

--- a/cryptarchia/test_ledger_state_update.py
+++ b/cryptarchia/test_ledger_state_update.py
@@ -45,9 +45,9 @@ def config() -> Config:
     return Config(
         k=10,
         active_slot_coeff=0.05,
-        epoch_stake_distribution_stabilization=4,
+        epoch_stake_distribution_stabilization=3,
         epoch_period_nonce_buffer=3,
-        epoch_period_nonce_stabilization=3,
+        epoch_period_nonce_stabilization=4,
         time=TimeConfig(slot_duration=1, chain_start_time=0),
     )
 
@@ -121,18 +121,8 @@ class TestLedgerStateUpdate(TestCase):
         leader_coins = [Coin(sk=i, value=100) for i in range(4)]
         genesis = mk_genesis_state(leader_coins)
 
-        # An epoch will be 10 slots long, with stake distribution snapshot taken at the start of the epoch
-        # and nonce snapshot before slot 7
-        config = Config(
-            k=1,
-            active_slot_coeff=1,
-            epoch_stake_distribution_stabilization=4,
-            epoch_period_nonce_buffer=3,
-            epoch_period_nonce_stabilization=3,
-            time=TimeConfig(slot_duration=1, chain_start_time=0),
-        )
+        follower = Follower(genesis, config())
 
-        follower = Follower(genesis, config)
         block_1 = mk_block(slot=0, parent=genesis.block, coin=leader_coins[0])
         follower.on_block(block_1)
         assert follower.tip() == block_1
@@ -165,16 +155,7 @@ class TestLedgerStateUpdate(TestCase):
 
         genesis = mk_genesis_state([coin])
 
-        config = Config(
-            k=1,
-            active_slot_coeff=1,
-            epoch_stake_distribution_stabilization=4,
-            epoch_period_nonce_buffer=3,
-            epoch_period_nonce_stabilization=3,
-            time=TimeConfig(slot_duration=1, chain_start_time=0),
-        )
-
-        follower = Follower(genesis, config)
+        follower = Follower(genesis, config())
 
         # coin wins the first slot
         block_1 = mk_block(slot=0, parent=genesis.block, coin=coin)
@@ -195,18 +176,7 @@ class TestLedgerStateUpdate(TestCase):
         coin = Coin(sk=0, value=100)
         genesis = mk_genesis_state([coin])
 
-        # An epoch will be 10 slots long, with stake distribution snapshot taken at the start of the epoch
-        # and nonce snapshot before slot 7
-        config = Config(
-            k=1,
-            active_slot_coeff=1,
-            epoch_stake_distribution_stabilization=4,
-            epoch_period_nonce_buffer=3,
-            epoch_period_nonce_stabilization=3,
-            time=TimeConfig(slot_duration=1, chain_start_time=0),
-        )
-
-        follower = Follower(genesis, config)
+        follower = Follower(genesis, config())
 
         # ---- EPOCH 0 ----
 
@@ -259,18 +229,7 @@ class TestLedgerStateUpdate(TestCase):
         coin = Coin(sk=0, value=100)
         genesis = mk_genesis_state([coin])
 
-        # An epoch will be 10 slots long, with stake distribution snapshot taken at the start of the epoch
-        # and nonce snapshot before slot 7
-        config = Config(
-            k=1,
-            active_slot_coeff=1,
-            epoch_stake_distribution_stabilization=4,
-            epoch_period_nonce_buffer=3,
-            epoch_period_nonce_stabilization=3,
-            time=TimeConfig(slot_duration=1, chain_start_time=0),
-        )
-
-        follower = Follower(genesis, config)
+        follower = Follower(genesis, config())
 
         # ---- EPOCH 0 ----
 

--- a/cryptarchia/test_ledger_state_update.py
+++ b/cryptarchia/test_ledger_state_update.py
@@ -246,7 +246,9 @@ class TestLedgerStateUpdate(TestCase):
         follower.on_block(block_0_1)
         # the coin evolved twice should not be accepted as it is not in the lead commitments
         assert follower.tip() == block_0_0
-        # an orphaned proof with an evolved coin for the same slot as the original coin should not be accepted as the evolved coin is not in the lead commitments at slot 0
+
+        # an orphaned proof with an evolved coin for the same slot as the original coin
+        # should not be accepted as the evolved coin is not in the lead commitments at slot 0
         block_0_1 = mk_block(
             slot=1,
             parent=block_0_0.id(),
@@ -255,7 +257,9 @@ class TestLedgerStateUpdate(TestCase):
         )
         follower.on_block(block_0_1)
         assert follower.tip() == block_0_0
-        # the coin evolved twice should be accepted as the evolved coin is in the lead commitments at slot 1 and processed before that
+
+        # the coin evolved twice should be accepted as the evolved coin is in the lead commitments
+        # at slot 1 and processed before that
         block_0_2 = mk_block(
             slot=2,
             parent=block_0_0.id(),


### PR DESCRIPTION
Currently the epoch stabilization schedule is only set in tests, we've defined the spec to allow any schedule when instantiated. This PR mostly updates the tests to reflect the new schedule:

The epoch stabilization schedule controls the order that epoch state data is stabilized and the duration of each stabilization period.

Previously ouroborous followed a 4 3 3 schedule (4k/f, 3k/f, 3k/f slots).

the first 4k/f + 3k/f = 7k/f slots were a buffer between when the stake distribution snapshot was taken and when the nonce snapshot is taken. The intention is to have a wide enough gap to prevent any adversary from having being able to influence the next epoch's nonce through coin grinding.

The move to 3 3 4 schedule means we have a gap of 6k/f slots between when the stake distribution snapshot and nonce snapshots are taken.

This new schedule gives more time for the nonce to stabilize before we enter the next epoch (entering a new epoch without a stable nonce would be quite chaotic, I don't think oroborous has contingencies in place for such an event)


This change in cardano / oroborous is here: https://github.com/IntersectMBO/ouroboros-consensus/pull/927