### PR TITLE
DA Api Tests

### DIFF
--- a/da/api/common.py
+++ b/da/api/common.py
@@ -8,15 +8,19 @@ from da.verifier import DABlob
 
 @dataclass
 class Metadata:
-    # index of VID certificate blob
-    index: int
     # app identifier
     app_id: bytes
+    # index of VID certificate blob
+    index: int
+
 
 @dataclass
-class VID():
+class VID:
+    # da certificate id
     cert_id: bytes
+    # application + index information
     metadata: Metadata
+
 
 class BlobStore(ABC):
     @abstractmethod

--- a/da/api/common.py
+++ b/da/api/common.py
@@ -13,6 +13,10 @@ class Metadata:
     # app identifier
     app_id: bytes
 
+@dataclass
+class VID():
+    cert_id: bytes
+    metadata: Metadata
 
 class BlobStore(ABC):
     @abstractmethod

--- a/da/api/test_flow.py
+++ b/da/api/test_flow.py
@@ -23,12 +23,12 @@ class MockStore(BlobStore):
             raise ValueError("index already written")
 
         blob = self.blob_store.pop(cert_id)
-        self.app_id_store[metadata.app_id][metadata.index] = blob 
+        self.app_id_store[metadata.app_id][metadata.index] = blob
 
     # Implements `get_multiple` method from BlobStore abstract class.
     def get_multiple(self, app_id, indexes) -> List[Optional[DABlob]]:
         return [
-                self.app_id_store[app_id].get(i) for i in indexes
+            self.app_id_store[app_id].get(i) for i in indexes
         ]
 
 

--- a/da/api/test_flow.py
+++ b/da/api/test_flow.py
@@ -22,14 +22,14 @@ class MockStore(BlobStore):
         if metadata.index in self.app_id_store[metadata.app_id]:
             raise ValueError("index already written")
 
-        blob = self.blob_store.pop(cert_id)
-        self.app_id_store[metadata.app_id][metadata.index] = blob
+        self.app_id_store[metadata.app_id][metadata.index] = cert_id
 
     # Implements `get_multiple` method from BlobStore abstract class.
     def get_multiple(self, app_id, indexes) -> List[Optional[DABlob]]:
         return [
-            self.app_id_store[app_id].get(i) for i in indexes
+            self.blob_store.get(self.app_id_store[app_id].get(i), None) if self.app_id_store[app_id].get(i) else None for i in indexes
         ]
+
 
 
 class TestFlow(TestCase):
@@ -69,4 +69,29 @@ class TestFlow(TestCase):
         blobs = api.read(app_id, [idx])
 
         self.assertEqual([expected_blob], blobs)
+
+    def test_multiple_indexes_same_data(self):
+        expected_blob = "hello"
+        cert_id = b"11"*32
+        app_id = 1
+        idx1 = 1
+        idx2 = 2
+        mock_meta1 = Metadata(app_id, idx1)
+        mock_meta2 = Metadata(app_id, idx2)
+
+        mock_store = MockStore()
+        mock_store.populate(expected_blob, cert_id)
+
+        api = DAApi(mock_store)
+
+        api.write(cert_id, mock_meta1)
+        mock_store.populate(expected_blob, cert_id)
+        api.write(cert_id, mock_meta2)
+
+        blobs_idx1 = api.read(app_id, [idx1])
+        blobs_idx2 = api.read(app_id, [idx2])
+
+        self.assertEqual([expected_blob], blobs_idx1)
+        self.assertEqual([expected_blob], blobs_idx2)
+        self.assertEqual(mock_store.app_id_store[app_id][idx1], mock_store.app_id_store[app_id][idx2])
 

--- a/da/common.py
+++ b/da/common.py
@@ -55,6 +55,9 @@ class Certificate:
     aggregated_column_commitment: Commitment
     row_commitments: List[Commitment]
 
+    def id(self) -> bytes:
+        return build_attestation_message(self.aggregated_column_commitment, self.row_commitments)
+
     def verify(self, nodes_public_keys: List[BLSPublickey]) -> bool:
         """
         List of nodes public keys should be a trusted list of verified proof of possession keys.

--- a/da/test_full_flow.py
+++ b/da/test_full_flow.py
@@ -1,0 +1,83 @@
+from unittest import TestCase
+from typing import List, Optional
+from py_ecc.bls import G2ProofOfPossession as bls_pop
+
+from da.common import Certificate, NodeId, build_attestation_message
+from da.api.common import DAApi, VID, Metadata
+from da.verifier import DAVerifier, DABlob 
+from da.api.test_flow import MockStore
+from da.dispersal import Dispersal, EncodedData, DispersalSettings
+from da.test_encoder import TestEncoder
+from da.encoder import DAEncoderParams, DAEncoder
+
+class DAVerifierWApi():
+    def __init__(self, sk: int):
+        self.store = MockStore()
+        self.api = DAApi(self.store)
+        self.verifier = DAVerifier(sk)
+
+    def receive_blob(self, blob: DABlob):
+        if attestation := self.verifier.verify(blob):
+            # Warning: If aggregated col commitment and row commitment are the same,
+            # the build_attestation_message method will produce the same output.
+            cert_id = build_attestation_message(blob.aggregated_column_commitment, blob.rows_commitments)
+            self.store.populate(blob, cert_id)
+            return attestation
+
+    def receive_cert(self, vid: VID):
+        # Usually the certificate would be verifier here, but we are assuming that this it is already comming from the verified block, in which case all certificates had been already verified by the DA Node.
+        self.api.write(vid.cert_id, vid.metadata) 
+
+    def read(self, app_id, indexes) -> List[Optional[DABlob]]:
+        self.api.read(app_id, indexes)
+
+class TestFullFlow(TestCase):
+    def setUp(self):
+        self.n_nodes = 16
+        self.nodes_ids = [NodeId(x.to_bytes(length=32, byteorder='big')) for x in range(self.n_nodes)]
+        self.secret_keys = list(range(1, self.n_nodes+1))
+        self.public_keys = [bls_pop.SkToPk(sk) for sk in self.secret_keys]
+        dispersal_settings = DispersalSettings(
+            self.nodes_ids,
+            self.public_keys,
+            self.n_nodes // 2 + 1
+        )
+        self.dispersal = Dispersal(dispersal_settings)
+        self.encoder_test = TestEncoder()
+        self.encoder_test.setUp()
+
+        self.api_nodes = [ DAVerifierWApi(k) for k in self.secret_keys ]
+
+
+    def test_full_flow(self):
+        app_id = int.to_bytes(1)
+        index = 1
+
+        # encoder
+        data = self.encoder_test.data
+        encoding_params = DAEncoderParams(column_count=self.n_nodes // 2, bytes_per_field_element=32)
+        encoded_data = DAEncoder(encoding_params).encode(data)
+
+        # mock send and await method with local verifiers
+        def __send_and_await_response(node: int, blob: DABlob):
+            node = self.api_nodes[int.from_bytes(node)]
+            return node.receive_blob(blob)
+
+        # inject mock send and await method
+        self.dispersal._send_and_await_response = __send_and_await_response
+        certificate = self.dispersal.disperse(encoded_data)
+
+        print(">>>>", self.api_nodes[0].store.blob_store)
+
+        vid = VID(
+                certificate.id(),
+                Metadata(app_id, index)
+            )
+
+        # verifier
+        for node in self.api_nodes:
+            node.receive_cert(vid)
+
+        # read from api and confirm its working
+        blobs = [node.read(app_id, index) for node in self.api_nodes]
+        blobs.sort(key = lambda x: x.index)

--- a/da/test_full_flow.py
+++ b/da/test_full_flow.py
@@ -1,16 +1,19 @@
+from itertools import chain
 from unittest import TestCase
 from typing import List, Optional
+
 from py_ecc.bls import G2ProofOfPossession as bls_pop
 
-from da.common import Certificate, NodeId, build_attestation_message
+from da.common import NodeId, build_attestation_message
 from da.api.common import DAApi, VID, Metadata
 from da.verifier import DAVerifier, DABlob 
 from da.api.test_flow import MockStore
-from da.dispersal import Dispersal, EncodedData, DispersalSettings
+from da.dispersal import Dispersal, DispersalSettings
 from da.test_encoder import TestEncoder
 from da.encoder import DAEncoderParams, DAEncoder
 
-class DAVerifierWApi():
+
+class DAVerifierWApi:
     def __init__(self, sk: int):
         self.store = MockStore()
         self.api = DAApi(self.store)
@@ -25,11 +28,14 @@ class DAVerifierWApi():
             return attestation
 
     def receive_cert(self, vid: VID):
-        # Usually the certificate would be verifier here, but we are assuming that this it is already comming from the verified block, in which case all certificates had been already verified by the DA Node.
+        # Usually the certificate would be verifier here,
+        # but we are assuming that this it is already coming from the verified block,
+        # in which case all certificates had been already verified by the DA Node.
         self.api.write(vid.cert_id, vid.metadata) 
 
     def read(self, app_id, indexes) -> List[Optional[DABlob]]:
-        self.api.read(app_id, indexes)
+        return self.api.read(app_id, indexes)
+
 
 class TestFullFlow(TestCase):
     def setUp(self):
@@ -40,14 +46,13 @@ class TestFullFlow(TestCase):
         dispersal_settings = DispersalSettings(
             self.nodes_ids,
             self.public_keys,
-            self.n_nodes // 2 + 1
+            self.n_nodes
         )
         self.dispersal = Dispersal(dispersal_settings)
         self.encoder_test = TestEncoder()
         self.encoder_test.setUp()
 
-        self.api_nodes = [ DAVerifierWApi(k) for k in self.secret_keys ]
-
+        self.api_nodes = [DAVerifierWApi(k) for k in self.secret_keys]
 
     def test_full_flow(self):
         app_id = int.to_bytes(1)
@@ -67,17 +72,21 @@ class TestFullFlow(TestCase):
         self.dispersal._send_and_await_response = __send_and_await_response
         certificate = self.dispersal.disperse(encoded_data)
 
-        print(">>>>", self.api_nodes[0].store.blob_store)
-
         vid = VID(
-                certificate.id(),
-                Metadata(app_id, index)
-            )
+            certificate.id(),
+            Metadata(app_id, index)
+        )
 
         # verifier
         for node in self.api_nodes:
             node.receive_cert(vid)
 
         # read from api and confirm its working
-        blobs = [node.read(app_id, index) for node in self.api_nodes]
-        blobs.sort(key = lambda x: x.index)
+        # notice that we need to sort the api_nodes by their public key to have the blobs sorted in the same fashion
+        # we do actually do dispersal.
+        blobs = list(chain.from_iterable(
+            node.read(app_id, [index])
+            for node in sorted(self.api_nodes, key=lambda n: bls_pop.SkToPk(n.verifier.sk))
+        ))
+        original_blobs = list(self.dispersal._prepare_data(encoded_data))
+        self.assertEqual(blobs, original_blobs)

--- a/da/test_full_flow.py
+++ b/da/test_full_flow.py
@@ -60,7 +60,7 @@ class TestFullFlow(TestCase):
 
         # encoder
         data = self.encoder_test.data
-        encoding_params = DAEncoderParams(column_count=self.n_nodes // 2, bytes_per_field_element=32)
+        encoding_params = DAEncoderParams(column_count=self.n_nodes // 2, bytes_per_chunk=31)
         encoded_data = DAEncoder(encoding_params).encode(data)
 
         # mock send and await method with local verifiers
@@ -97,7 +97,7 @@ class TestFullFlow(TestCase):
 
         # encoder
         data = self.encoder_test.data
-        encoding_params = DAEncoderParams(column_count=self.n_nodes // 2, bytes_per_field_element=32)
+        encoding_params = DAEncoderParams(column_count=self.n_nodes // 2, bytes_per_chunk=31)
         encoded_data = DAEncoder(encoding_params).encode(data)
 
         # mock send and await method with local verifiers


### PR DESCRIPTION
DA Api main methods definition and tests using Nomos DA Protocol.

The latest revision focuses only on `read` and `write` methods and provides `MockBlobStore` to demonstrate a naive way of indexing blobs for a specific `app_id`.

Two new definitions were added to the overall DA spec:
- VID - verifiable information dispersal structure, which is written into a block after attestations for an original data dispersal are verified by block producer.
  - VID holds two fields: `cert_id` and `metadata`
    - `cert_id` is derived from `aggregated_column_commitment` and `rows_commitments` using [_build_attestation_message](https://github.com/logos-co/nomos-specs/blob/b1e13f79c5e4ddefbd8424a3188bc093c355d234/da/dispersal.py#L73)
    - `metadata` is received together with the actual dispersal certificate from EZ 
- Metadata - holds `app_id` and `index` of the related original data

The `da/test_full_flow.py` shows a full cycle of original data being stored and retrieved from Nomos DA:
- Original data is encoded into blobs;
- Blobs are dispersed to nodes;
- Attestations are collected and Certificate is formed;
- VID is formed from the Certificate;
- Nodes receive the VID and index the blobs;
- `read` request is issued to all Nodes to receive specific blob for `index` of `app_id`
- collected blobs are compared to the original blobs