### PR TITLE
DA: Encode arbitrary data

### DIFF
--- a/da/common.py
+++ b/da/common.py
@@ -11,7 +11,7 @@ class NodeId(Bytes32):
     pass
 
 
-class Chunk(Bytes32):
+class Chunk(bytes):
     pass
 
 

--- a/da/kzg_rs/kzg.py
+++ b/da/kzg_rs/kzg.py
@@ -9,12 +9,12 @@ from .common import BYTES_PER_FIELD_ELEMENT, G1, BLS_MODULUS, GLOBAL_PARAMETERS_
 from .poly import Polynomial
 
 
-def bytes_to_polynomial(b: bytes) -> Polynomial:
+def bytes_to_polynomial(b: bytes, bytes_per_field_element=BYTES_PER_FIELD_ELEMENT) -> Polynomial:
     """
     Convert bytes to list of BLS field scalars.
     """
-    assert len(b) % BYTES_PER_FIELD_ELEMENT == 0
-    eval_form = [int(bytes_to_bls_field(b)) for b in batched(b, int(BYTES_PER_FIELD_ELEMENT))]
+    assert len(b) % bytes_per_field_element == 0
+    eval_form = [int(bytes_to_bls_field(b)) for b in batched(b, int(bytes_per_field_element))]
     return Polynomial.from_evaluations(eval_form, BLS_MODULUS)
 
 
@@ -34,7 +34,7 @@ def g1_linear_combination(polynomial: Polynomial[BLSFieldElement], global_parame
 
 
 def bytes_to_commitment(b: bytes, global_parameters: Sequence[G1]) -> Tuple[Polynomial, Commitment]:
-    poly = bytes_to_polynomial(b)
+    poly = bytes_to_polynomial(b, bytes_per_field_element=BYTES_PER_FIELD_ELEMENT)
     return poly, g1_linear_combination(poly, global_parameters)
 
 

--- a/da/kzg_rs/rs.py
+++ b/da/kzg_rs/rs.py
@@ -1,9 +1,7 @@
-from typing import Sequence, List
+from typing import Sequence
 
-import scipy.interpolate
 from eth2spec.deneb.mainnet import BLSFieldElement
-from eth2spec.eip7594.mainnet import interpolate_polynomialcoeff
-from .common import G1, BLS_MODULUS
+from .common import BLS_MODULUS
 from .poly import Polynomial
 
 ExtendedData = Sequence[BLSFieldElement]

--- a/da/test_dispersal.py
+++ b/da/test_dispersal.py
@@ -50,7 +50,7 @@ class TestDispersal(TestCase):
 
     def test_disperse(self):
         data = self.encoder_test.data
-        encoding_params = DAEncoderParams(column_count=self.n_nodes // 2, bytes_per_field_element=32)
+        encoding_params = DAEncoderParams(column_count=self.n_nodes // 2, bytes_per_chunk=31)
         encoded_data = DAEncoder(encoding_params).encode(data)
 
         # mock send and await method with local verifiers


### PR DESCRIPTION
We use field elements of size 32 bytes, but not every arbitrary 32 bytes can be encoded as field points in the bls381 curve. For that we can only chunk up to 31 bytes which are then extended to 32 bytes elements.