### PR TITLE
Add `pyproject.toml` so that other projects can reference it

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,4 @@
 [submodule "consensus-specs"]
 	path = eth-specs
-	url = git@github.com:ethereum/consensus-specs.git
+	url = https://github.com/ethereum/consensus-specs.git
 	branch = dev

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,34 @@
+[project]
+name = "nomos-specs"
+version = "0.0.1"
+description = "Nomos executable specifications"
+readme = "README.md"
+requires-python = ">=3.10"
+classifiers = [
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3 :: Only",
+    "Operating System :: OS Independent",
+]
+dynamic = ["dependencies"]
+
+[project.urls]
+Homepage = "https://github.com/logos-co/nomos-specs"
+Issues = "https://github.com/logos-co/nomos-specs/issues"
+
+[build-system]
+requires = ["hatchling", "hatch-requirements-txt"]
+build-backend = "hatchling.build"
+
+[tool.hatch.build.targets.sdist]
+# Include only Python packages from this repository
+include = ["mixnet", "cryptarchia", "da"]
+
+[tool.hatch.build.targets.wheel]
+# Include only Python packages from this repository
+packages = ["mixnet", "cryptarchia", "da"]
+
+[tool.hatch.metadata.hooks.requirements_txt]
+files = ["requirements.txt"]


### PR DESCRIPTION
## Motivation

Some Python packages in this repo need to be referenced by other projects such as `nomos-simulations`. 

Although the simulations and PoCs need to be done in prior to writing executable specs in this repo, some simulations need to be based on existing specs defined in repo. For example, the mixnet simulation is based on some code in this repo that was defined long time ago.

So, instead of maintaining the same code in different repos, I made this repo can be referenced by other projects. 

## Changes. 

I added `pyproject.toml`. Although we are not going to publish this repo to PyPI right now, we need this file, so that other projects can reference it by specifying the following dependency in their `requirements.txt`.
```
git+https://github.com/logos-co/nomos-specs.git@{branch-name}
```
Then, they can import packages like:
```
from mixnet.config import MixnetConfig
```
This `pyproject.toml` includes only Python packages (`mixnet`, `cryptarchia`, `da`), not Rust packages (`cl`, `goas`).

I tested this in my local. The related PR is coming soon in the `nomos-simulations` repo.

## Notes
According to PEP 8 style guide, it's better to move all subpackages into the new `nomos_specs` directory, so that they can be imported by `from nomos_specs.mixnet.config import MixnetConfig`. But, I didn't change the directory structure in this PR for now to make changes simpler. I think it's not bad to do `from mixnet....` because we are not publishing this to PyPI. Later, we can reorganize the directory structure if needed.
```
nomos-specs/
    pyproject.toml
    nomos_specs/
        __init__.py
        mixnet/
            __init__.py
            some_module.py
        cryptarchia/
            __init__.py
            some_module.py
        da/
            __init__.py
            some_module.py
        ...