### PR TITLE
Remove leader proof commitment from code

### DIFF
--- a/cryptarchia/cryptarchia.py
+++ b/cryptarchia/cryptarchia.py
@@ -224,9 +224,6 @@ class BlockHeader:
         assert len(self.parent) == 32
         h.update(self.parent)
 
-        # leader proof
-        assert len(self.leader_proof.commitment) == 32
-        h.update(self.leader_proof.commitment)
         assert len(self.leader_proof.nullifier) == 32
         h.update(self.leader_proof.nullifier)
         assert len(self.leader_proof.evolved_commitment) == 32


### PR DESCRIPTION
The commitment used should stay hidden, no reason to use that to compute the header id