### PR TITLE
NomosDA update v1 verifier

### DIFF
--- a/da/test_verifier.py
+++ b/da/test_verifier.py
@@ -69,4 +69,4 @@ class TestVerifier(TestCase):
                 encoded_data.row_commitments,
                 [row[i] for row in encoded_data.row_proofs],
             )
-            self.assertFalse(self.verifier.verify(da_blob))
+            self.assertTrue(self.verifier.verify(da_blob))


### PR DESCRIPTION
Targets `update-v1` [PR](https://github.com/logos-co/nomos-specs/pull/117), removes mentions about attestations, simplifies the verifier function with a comment about the implementer responsibility to make verification idempotent. 