### PR TITLE
build: pin python to 3.12 (not 3.13) due to outdated dependencies

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,11 +15,11 @@ jobs:
       - uses: actions/checkout@v4
         with:
           submodules: true
-      - name: Set up Python 3.x
+      - name: Set up Python 3.12
         uses: actions/setup-python@v5
         with:
           # Semantic version range syntax or exact version of a Python version
-          python-version: '3.x'
+          python-version: '3.12'
       - name: Install dependencies
         run: pip install -r requirements.txt
       - name: Build and install eth-specs

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Set up Python 3.12
         uses: actions/setup-python@v5
         with:
-          # Semantic version range syntax or exact version of a Python version
+          # TODO: Revert this to '3.x' once we have an updated version of `poseidon-hash` that works for Python >=3.13.
           python-version: '3.12'
       - name: Install dependencies
         run: pip install -r requirements.txt


### PR DESCRIPTION
Recently, the `actions/setup-python@v5` has started installing Python 3.13 instead of 3.12. Ideally our code should work with 3.13, but installing dependencies is failing.

The first error is:
```
      ../scipy/meson.build:159:9: ERROR: Dependency "OpenBLAS" not found, tried pkgconfig and cmake
```
https://github.com/logos-co/nomos-specs/actions/runs/13521718813/job/37782294686#step:4:103
This can be resolved by upgrading `scipy` to the latest (1.15.2). I tested it in my local.

However, I got another error when installing [`poseidon-hash==0.1.4`](https://github.com/logos-co/nomos-specs/blob/5c64a0bd11b4e0ef9d896297e14735f1f8a530cd/requirements.txt#L14).
```
Collecting numba<0.60,>=0.55 (from galois~=0.3.6->poseidon-hash==0.1.4->-r requirements.txt (line 14))
...
      RuntimeError: Cannot install on Python version 3.13.2; only versions >=3.9,<3.13 are supported.
```
`numba` and `galois` have been upgraded for Python 3.13, but there's no update on `poseidon-hash` yet. 

Until we have an updated version of `poseidon-hash`, we still should use Python 3.12.