### PR TITLE
Add Boostrapping/Online modes

### DIFF
--- a/cryptarchia/test_fork_choice.py
+++ b/cryptarchia/test_fork_choice.py
@@ -6,9 +6,11 @@ from cryptarchia.cryptarchia import (
     maxvalid_mc,
     Slot,
     Note,
+    State,
     Follower,
     common_prefix_depth,
     LedgerState,
+    ImmutableFork,
 )
 
 from .test_common import mk_chain, mk_config, mk_genesis_state, mk_block
@@ -301,39 +303,74 @@ class TestForkChoice(TestCase):
         assert len(follower.forks) == 1 and follower.forks[0] == b2.id(), follower.forks
 
         # -- switch to online mode --
-        follower.to_online()
-
-        # -- extend a fork deeper than k --
         #
-        #
-        #    b2 - b5 - b6
+        #    b2 (does not descend from the LIB and is thus pruned)
         #   /
         # b1
         #   \
-        #    b3 - b4 == tip
+        #    b3 (LIB) - b4 == tip
         #
-        b5 = mk_block(b2, 3, n_a)
-        b6 = mk_block(b5, 4, n_a)
-        follower.on_block(b5)
-        follower.on_block(b6)
+        follower.to_online()
+        assert follower.lib == b3.id(), follower.lib
+        assert len(follower.forks) == 0, follower.forks
+        assert b2.id() not in follower.forks
 
-        assert follower.tip_id() == b4.id()
-        assert len(follower.forks) == 1 and follower.forks[0] == b6.id()
+        # -- extend a fork deeper than the LIB --
+        #
+        #     - - - - - - b5
+        #   /
+        # b1
+        #   \
+        #    b3 (LIB) - b4 == tip
+        #
+        b5 = mk_block(b1, 4, n_a)
+        with self.assertRaises(ImmutableFork):
+            follower.on_block(b5)
 
         # -- extend the main chain shallower than k --
         #
-        #
-        #    b2 - b5 - b6
-        #   /
         # b1
         #   \
-        #    b3 - b4
+        #    b3 - b4 (pruned)
         #    \
-        #     - - b7 - b8 == tip
+        #     - - b7 (LIB) - b8 == tip
         b7 = mk_block(b3, 4, n_b)
         b8 = mk_block(b7, 5, n_b)
 
         follower.on_block(b7)
+        assert len(follower.forks) == 1 and b7.id() in follower.forks
+
         follower.on_block(b8)
         assert follower.tip_id() == b8.id()
-        assert len(follower.forks) == 2 and {b6.id(), b4.id()}.issubset(follower.forks)
+        # b4 was pruned as it forks deeper than the LIB
+        assert len(follower.forks) == 0, follower.forks
+
+        # Even in bootstrap mode, the follower should not accept blocks that fork deeper than k
+        follower.state = State.BOOTSTRAPPING
+        with self.assertRaises(ImmutableFork):
+            follower.on_block(b5)
+
+        # But it should switch a chain diverging more than k as long as it
+        # descends from the LIB
+        #
+        # b1
+        #   \
+        #    b3    - - - - - - - b10 - b11 - b12
+        #    \     |
+        #     - - b7 (LIB) - b8 - b9 == tip
+        b8 = mk_block(b7, 5, n_b)
+        b9 = mk_block(b8, 6, n_b)
+        b10 = mk_block(b7, 7, n_a)
+        b11 = mk_block(b10, 8, n_a)
+        b12 = mk_block(b11, 9, n_a)
+        follower.on_block(b8)
+        follower.on_block(b9)
+
+        assert follower.tip_id() == b9.id()
+
+        follower.on_block(b10)
+        follower.on_block(b11)
+        follower.on_block(b12)
+
+        assert follower.tip_id() == b12.id()
+        assert follower.lib == b7.id(), follower.lib


### PR DESCRIPTION
Add Boostrapping and Online modes to cryptarchia, including relevant tests. The Boostrap mode uses the Genesis fc rule, while Online uses Praos. Swtitching between the two rules is left to the implementation and is specified in the public Notion as linked in the comment