### PR TITLE
feat: Subnetwork assignations algorithm

### DIFF
--- a/da/api/common.py
+++ b/da/api/common.py
@@ -3,7 +3,7 @@ from dataclasses import dataclass
 from typing import Optional, List, Sequence
 
 from da.common import BlobId
-from da.verifier import DAShare
+from da.verifier import DABlob
 
 
 @dataclass

--- a/da/assignations/refill.py
+++ b/da/assignations/refill.py
@@ -1,0 +1,127 @@
+from dataclasses import dataclass
+from typing import List, Set, TypeAlias, Sequence
+from itertools import cycle, chain
+from collections import Counter
+from heapq import heappush, heappop, heapify
+
+DeclarationId:  TypeAlias = bytes
+Assignations: TypeAlias = List[Set[DeclarationId]]
+
+@dataclass(order=True)
+class Participant:
+    # Participants wrapper class
+    # Used for keeping ordering in the heap by the participation first and the declaration id second
+    participation: int              # prioritize participation count first
+    declaration_id: DeclarationId   # sort by id on default
+
+@dataclass
+class Subnetwork:
+    # Subnetwork wrapper that keeps the subnetwork id [0..2048) and the set of participants in that subnetwork
+    participants: Set[DeclarationId]
+    subnetwork_id: int
+
+    def __lt__(self, other):
+        return len(self) < len(other)
+
+    def __len__(self):
+        return len(self.participants)
+
+
+
+def are_subnetworks_filled_up_to_replication_factor(subnetworks: Sequence[Subnetwork], replication_factor: int) -> bool:
+    return all(len(subnetwork) >= replication_factor for subnetwork in subnetworks)
+
+def all_nodes_are_assigned(participants: Sequence[Participant]) -> bool:
+    return all(participant.participation > 0 for participant in participants)
+
+
+def heappop_next_for_participant(subnetworks: List[Subnetwork], participant: Participant) -> Subnetwork:
+    filtered = [subnetwork for subnetwork in subnetworks if participant.declaration_id not in subnetwork.participants]
+    poped = heappop(filtered)
+    subnetworks.remove(poped)
+    heapify(subnetworks)
+    return poped
+
+def calculate_subnetwork_assignations(
+        new_nodes_list: Sequence[DeclarationId],
+        previous_subnets: Assignations,
+        replication_factor: int
+) -> Assignations:
+    # The algorithm works as follows:
+    # 1. Remove nodes that are not active from the previous subnetworks assignations
+    # 2. Create a heap with the set of active nodes ordered by, primary the number of subnetworks each participant is at
+    #    and secondary by the DeclarationId of the participant (ascending order).
+    # 3. Create a heap with the subnetworks ordered by the number of participants in each subnetwork
+    # 4. Until all subnetworks are filled up to replication factor and all nodes are assigned:
+    #    1) pop the subnetwork with the least participants
+    #    2) pop the participant with less participations
+    #    3) push the participant into the subnetwork and increment its participation count
+    #    4) push the participant and the subnetwork into the respective heaps
+    # 5. Return the subnetworks ordered by its subnetwork id
+
+    # prepare sets
+    previous_nodes =  set(chain.from_iterable(previous_subnets))
+    new_nodes = set(new_nodes_list)
+    unavailable_nodes = previous_nodes - new_nodes
+
+    # remove unavailable nodes
+    active_assignations = [subnet - unavailable_nodes for subnet in previous_subnets]
+
+    # count participation per assigned node
+    assigned_count: Counter[DeclarationId] = Counter(chain.from_iterable(active_assignations))
+
+    # available nodes heap
+    available_nodes = [
+        Participant(participation=assigned_count.get(_id, 0), declaration_id=_id) for _id in new_nodes
+    ]
+    heapify(available_nodes)
+
+    # subnetworks heap
+    subnetworks = list(
+        Subnetwork(participants=subnet, subnetwork_id=subnetwork_id)
+        for subnetwork_id, subnet in enumerate(active_assignations)
+    )
+    heapify(subnetworks)
+
+
+    while not (
+        are_subnetworks_filled_up_to_replication_factor(subnetworks, replication_factor) and
+        all_nodes_are_assigned(available_nodes)
+    ):
+        # take less participations declaration
+        participant = heappop(available_nodes)
+
+        # take less participants subnetwork
+        subnetwork = heappop(subnetworks)
+
+        # fill into subnetwork
+        subnetwork.participants.add(participant.declaration_id)
+        participant.participation += 1
+        # push to queues
+        heappush(available_nodes, participant)
+        heappush(subnetworks, subnetwork)
+    return [subnetwork.participants for subnetwork in sorted(subnetworks, key=lambda x: x.subnetwork_id)]
+
+
+
+
+if __name__ == "__main__":
+    import random
+    number_of_columns = 4096
+    for size in [100, 500, 1000, 10000]:
+        nodes_ids = [random.randbytes(32) for _ in range(size)]
+        replication_factor = 3
+        print(size, replication_factor)
+        # print(a := calculate_subnets(nodes_ids, number_of_columns, replication_factor))
+        from pprint import pprint
+        b = calculate_subnetwork_assignations(nodes_ids, [set() for _ in range(number_of_columns)], replication_factor)
+        # pprint(b)
+        assert len(set(chain.from_iterable(b))) == len(nodes_ids)
+        # fill up new nodes
+        for i in range(0, size, 5):
+            nodes_ids[i] = random.randbytes(32)
+        b = calculate_subnetwork_assignations(nodes_ids, b, replication_factor)
+        # pprint(b)
+        assert len(set(chain.from_iterable(b))) == len(nodes_ids), f"{len(set(chain.from_iterable(b)))} != {len(nodes_ids)}"
+        print(Counter(chain.from_iterable(b)).values())
+

--- a/da/assignations/test_refill.py
+++ b/da/assignations/test_refill.py
@@ -1,0 +1,59 @@
+import random
+from itertools import chain
+from typing import List
+from unittest import TestCase
+from da.assignations.refill import calculate_subnetwork_assignations, Assignations, DeclarationId
+
+
+class TestRefill(TestCase):
+    def test_single_with(self, subnetworks_size = 2048, replication_factor: int = 3, network_size: int = 100):
+        nodes = [random.randbytes(32) for _ in range(network_size)]
+        previous_nodes = [set() for _ in range(subnetworks_size)]
+        assignations = calculate_subnetwork_assignations(nodes, previous_nodes, replication_factor)
+        self.assert_assignations(assignations, nodes, replication_factor)
+
+    def test_single_network_sizes(self):
+        for i in [500, 1000, 10000, 100000]:
+            with self.subTest(i):
+                self.test_single_with(network_size=i)
+
+    def test_same_sized_evolving_network(self):
+        network_size = 100
+        replication_factor = 3
+        nodes = [random.randbytes(32) for _ in range(network_size)]
+        assignations = [set() for _ in range(network_size)]
+        assignations = calculate_subnetwork_assignations(nodes, assignations, replication_factor)
+        for network_size in [300, 500, 1000, 10000, 100000]:
+            new_nodes = self.expand_nodes(nodes, network_size)
+            self.mutate_nodes(new_nodes, network_size//3)
+            assignations = calculate_subnetwork_assignations(new_nodes, assignations, replication_factor)
+            self.assert_assignations(assignations, new_nodes, replication_factor)
+
+    @classmethod
+    def mutate_nodes(cls, nodes: List[DeclarationId], count: int):
+        assert count < len(nodes)
+        for i in random.choices(list(range(len(nodes))), k=count):
+            nodes[i] = random.randbytes(32)
+
+    @classmethod
+    def expand_nodes(cls, nodes: List[DeclarationId], count: int) -> List[DeclarationId]:
+        return [*nodes, *(random.randbytes(32) for _ in range(count))]
+
+
+    def assert_assignations(self, assignations: Assignations, nodes: List[DeclarationId], replication_factor: int):
+        self.assertEqual(
+            len(set(chain.from_iterable(assignations))),
+            len(nodes),
+            "Only active nodes should be assigned"
+        )
+        self.assertTrue(
+            all(len(assignation) >= replication_factor for assignation in assignations),
+            f"No subnetworks should have less than {replication_factor} nodes"
+        )
+        self.assertAlmostEqual(
+            max(map(len, assignations)),
+            min(map(len, assignations)),
+            msg="Subnetwork size variant should not be bigger than 1",
+            delta=1
+        )
+

--- a/da/common.py
+++ b/da/common.py
@@ -42,33 +42,6 @@ class Bitfield(List[bool]):
     pass
 
 
-@dataclass
-class Attestation:
-    signature: BLSSignature
-
-
-@dataclass
-class Certificate:
-    aggregated_signatures: BLSSignature
-    signers: Bitfield
-    aggregated_column_commitment: Commitment
-    row_commitments: List[Commitment]
-
-    def id(self) -> bytes:
-        return build_blob_id(self.aggregated_column_commitment, self.row_commitments)
-
-    def verify(self, nodes_public_keys: List[BLSPublicKey]) -> bool:
-        """
-        List of nodes public keys should be a trusted list of verified proof of possession keys.
-        Otherwise, we could fall under the Rogue Key Attack
-        `assert all(bls_pop.PopVerify(pk, proof) for pk, proof in zip(node_public_keys, pops))`
-        """
-        # we sort them as the signers bitfield is sorted by the public keys as well
-        signers_keys = list(compress(sorted(nodes_public_keys), self.signers))
-        message = build_blob_id(self.aggregated_column_commitment, self.row_commitments)
-        return NomosDaG2ProofOfPossession.AggregateVerify(signers_keys, [message]*len(signers_keys), self.aggregated_signatures)
-
-
 def build_blob_id(aggregated_column_commitment: Commitment, row_commitments: Sequence[Commitment]) -> BlobId:
     hasher = sha3_256()
     hasher.update(bytes(aggregated_column_commitment))

--- a/da/dispersal.py
+++ b/da/dispersal.py
@@ -32,41 +32,15 @@ class Dispersal:
             )
             yield blob
 
-    def _send_and_await_response(self, node: NodeId, blob: DAShare) -> bool:
+    def _send_and_await_response(self, node: NodeId, blob: DABlob) -> bool:
         pass
 
-    def _build_certificate(
-            self,
-            encoded_data: EncodedData,
-            attestations: Sequence[Attestation],
-            signers: Bitfield
-    ) -> Certificate:
-        assert len(attestations) >= self.settings.threshold
-        assert len(attestations) == signers.count(True)
-        aggregated = bls_pop.Aggregate([attestation.signature for attestation in attestations])
-        return Certificate(
-            aggregated_signatures=aggregated,
-            signers=signers,
-            aggregated_column_commitment=encoded_data.aggregated_column_commitment,
-            row_commitments=encoded_data.row_commitments
-        )
-
-    @staticmethod
-    def _verify_attestation(public_key: BLSPublicKey, attested_message: bytes, attestation: Attestation) -> bool:
-        return bls_pop.Verify(public_key, attested_message, attestation.signature)
-
-    @staticmethod
-    def _build_attestation_message(encoded_data: EncodedData) -> bytes:
-        return build_blob_id(encoded_data.aggregated_column_commitment, encoded_data.row_commitments)
-
-    def disperse(self, encoded_data: EncodedData) -> Optional[Certificate]:
+    def disperse(self, encoded_data: EncodedData):
         attestations = []
-        attested_message = self._build_attestation_message(encoded_data)
-        signed = Bitfield(False for _ in range(len(self.settings.nodes_ids)))
         blob_data = zip(
             self.settings.nodes_ids,
             self._prepare_data(encoded_data)
         )
-        for node, blob in blob_data:
+        for i, node, blob in blob_data:
             self._send_and_await_response(node, blob)
 

--- a/da/dispersal.py
+++ b/da/dispersal.py
@@ -41,11 +41,10 @@ class Dispersal:
         pass
 
     def disperse(self, encoded_data: EncodedData):
-        attestations = []
         blob_data = zip(
             self.settings.nodes_ids,
             self._prepare_data(encoded_data)
         )
-        for i, node, blob in blob_data:
+        for node, blob in blob_data:
             self._send_and_await_response(node, blob)
 

--- a/da/dispersal.py
+++ b/da/dispersal.py
@@ -1,7 +1,7 @@
 from dataclasses import dataclass
 from typing import List, Generator
 
-from da.common import NodeId, Column
+from da.common import Certificate, NodeId, BLSPublicKey, Bitfield, build_blob_id, NomosDaG2ProofOfPossession as bls_pop
 from da.encoder import EncodedData
 from da.verifier import DAShare
 
@@ -35,7 +35,34 @@ class Dispersal:
     def _send_and_await_response(self, node: NodeId, blob: DAShare) -> bool:
         pass
 
-    def disperse(self, encoded_data: EncodedData):
+    def _build_certificate(
+            self,
+            encoded_data: EncodedData,
+            attestations: Sequence[Attestation],
+            signers: Bitfield
+    ) -> Certificate:
+        assert len(attestations) >= self.settings.threshold
+        assert len(attestations) == signers.count(True)
+        aggregated = bls_pop.Aggregate([attestation.signature for attestation in attestations])
+        return Certificate(
+            aggregated_signatures=aggregated,
+            signers=signers,
+            aggregated_column_commitment=encoded_data.aggregated_column_commitment,
+            row_commitments=encoded_data.row_commitments
+        )
+
+    @staticmethod
+    def _verify_attestation(public_key: BLSPublicKey, attested_message: bytes, attestation: Attestation) -> bool:
+        return bls_pop.Verify(public_key, attested_message, attestation.signature)
+
+    @staticmethod
+    def _build_attestation_message(encoded_data: EncodedData) -> bytes:
+        return build_blob_id(encoded_data.aggregated_column_commitment, encoded_data.row_commitments)
+
+    def disperse(self, encoded_data: EncodedData) -> Optional[Certificate]:
+        attestations = []
+        attested_message = self._build_attestation_message(encoded_data)
+        signed = Bitfield(False for _ in range(len(self.settings.nodes_ids)))
         blob_data = zip(
             self.settings.nodes_ids,
             self._prepare_data(encoded_data)

--- a/da/dispersal.py
+++ b/da/dispersal.py
@@ -1,9 +1,9 @@
 from dataclasses import dataclass
 from typing import List, Generator
 
-from da.common import Certificate, NodeId, BLSPublicKey, Bitfield, build_blob_id, NomosDaG2ProofOfPossession as bls_pop
+from da.common import NodeId
 from da.encoder import EncodedData
-from da.verifier import DAShare
+from da.verifier import DABlob
 
 
 @dataclass

--- a/da/dispersal.py
+++ b/da/dispersal.py
@@ -21,14 +21,19 @@ class Dispersal:
     def _prepare_data(self, encoded_data: EncodedData) -> Generator[DAShare, None, None]:
         columns = encoded_data.extended_matrix.columns
         row_commitments = encoded_data.row_commitments
-        column_proofs = encoded_data.combined_column_proofs
-        blobs_data = zip(columns, column_proofs)
-        for column_idx, (column, proof) in enumerate(blobs_data):
-            blob = DAShare(
-                Column(column),
+        rows_proofs = encoded_data.row_proofs
+        aggregated_column_commitment = encoded_data.aggregated_column_commitment
+        aggregated_column_proofs = encoded_data.aggregated_column_proofs
+        blobs_data = zip(columns, column_commitments, zip(*rows_proofs), aggregated_column_proofs)
+        for column_idx, (column, column_commitment, row_proofs, column_proof) in enumerate(blobs_data):
+            blob = DABlob(
+                column,
                 column_idx,
-                proof,
-                row_commitments
+                column_commitment,
+                aggregated_column_commitment,
+                column_proof,
+                row_commitments,
+                row_proofs
             )
             yield blob
 

--- a/da/encoder.py
+++ b/da/encoder.py
@@ -86,11 +86,11 @@ class DAEncoder:
 
     @staticmethod
     def _compute_aggregated_column_commitment(
-        chunks_matrix: ChunksMatrix, column_commitments: Sequence[Commitment]
+        column_commitments: Sequence[Commitment]
     ) -> Tuple[Polynomial, Commitment]:
         data = bytes(chain.from_iterable(
-            DAEncoder.hash_commitment_blake2b31(column, commitment)
-            for column, commitment in zip(chunks_matrix.columns, column_commitments)
+            DAEncoder.hash_commitment_blake2b31(commitment)
+            for commitment in column_commitments
         ))
         return kzg.bytes_to_commitment(data, GLOBAL_PARAMETERS)
 
@@ -108,9 +108,14 @@ class DAEncoder:
         chunks_matrix = self._chunkify_data(data)
         row_polynomials, row_commitments = zip(*self._compute_row_kzg_commitments(chunks_matrix))
         extended_matrix = self._rs_encode_rows(chunks_matrix)
-        h = derive_challenge(row_commitments)
-        combined_poly = compute_combined_polynomial(row_polynomials, h)
-        combined_column_proofs = self._compute_combined_column_proofs(combined_poly)
+        row_proofs = self._compute_rows_proofs(extended_matrix, row_polynomials, row_commitments)
+        column_polynomials, column_commitments = zip(*self._compute_column_kzg_commitments(extended_matrix))
+        aggregated_column_polynomial, aggregated_column_commitment = (
+            self._compute_aggregated_column_commitment(column_commitments)
+        )
+        aggregated_column_proofs = self._compute_aggregated_column_proofs(
+            aggregated_column_polynomial, column_commitments
+        )
         result = EncodedData(
             data,
             chunks_matrix,
@@ -122,4 +127,7 @@ class DAEncoder:
 
     @staticmethod
     def hash_commitment_blake2b31(commitment: Commitment) -> bytes:
-        return blake2b(bytes(commitment), digest_size=31).digest()
+        return (
+            # digest size must be 31 bytes as we cannot encode 32 without risking overflowing the BLS_MODULUS
+            int.from_bytes(blake2b(bytes(commitment), digest_size=31).digest())
+        ).to_bytes(32, byteorder="big") # rewrap into 32 padded bytes for the field elements, EC library dependant

--- a/da/encoder.py
+++ b/da/encoder.py
@@ -6,7 +6,6 @@ from eth2spec.eip7594.mainnet import KZGCommitment as Commitment, KZGProof as Pr
 
 from da.common import ChunksMatrix, Chunk, Row
 from da.kzg_rs import kzg, rs
-from da.kzg_rs.bdfg_proving import derive_challenge
 from da.kzg_rs.common import GLOBAL_PARAMETERS, ROOTS_OF_UNITY, BYTES_PER_FIELD_ELEMENT
 from da.kzg_rs.poly import Polynomial
 from da.kzg_rs.bdfg_proving import compute_combined_polynomial

--- a/da/test_dispersal.py
+++ b/da/test_dispersal.py
@@ -2,8 +2,8 @@ from unittest import TestCase
 
 from da.encoder import DAEncoderParams, DAEncoder
 from da.test_encoder import TestEncoder
-from da.verifier import DAVerifier, DAShare
-from da.common import NodeId
+from da.verifier import DAVerifier, DABlob
+from da.common import NodeId, NomosDaG2ProofOfPossession as bls_pop
 from da.dispersal import Dispersal, DispersalSettings
 
 
@@ -25,15 +25,11 @@ class TestDispersal(TestCase):
         encoded_data = DAEncoder(encoding_params).encode(data)
 
         # mock send and await method with local verifiers
-        verifiers_res = []
-        def __send_and_await_response(_, blob: DAShare):
+        def __send_and_await_response(blob: DABlob):
             verifier = DAVerifier()
-            res = verifier.verify(blob)
-            verifiers_res.append(res)
-            return res
+            return verifier.verify(blob)
         # inject mock send and await method
         self.dispersal._send_and_await_response = __send_and_await_response
-        self.dispersal.disperse(encoded_data)
-        for res in verifiers_res:
-            self.assertTrue(res)
+
+        self.assertTrue(self.dispersal.disperse(encoded_data))
 

--- a/da/test_dispersal.py
+++ b/da/test_dispersal.py
@@ -25,11 +25,15 @@ class TestDispersal(TestCase):
         encoded_data = DAEncoder(encoding_params).encode(data)
 
         # mock send and await method with local verifiers
-        def __send_and_await_response(blob: DABlob):
+        verifiers_res = []
+        def __send_and_await_response(_, blob: DABlob):
             verifier = DAVerifier()
-            return verifier.verify(blob)
+            res = verifier.verify(blob)
+            verifiers_res.append(res)
+            return res
         # inject mock send and await method
         self.dispersal._send_and_await_response = __send_and_await_response
-
-        self.assertTrue(self.dispersal.disperse(encoded_data))
+        self.dispersal.disperse(encoded_data)
+        for res in verifiers_res:
+            self.assertTrue(res)
 

--- a/da/test_encoder.py
+++ b/da/test_encoder.py
@@ -87,12 +87,23 @@ class TestEncoder(TestCase):
 
     def test_generate_combined_column_proofs(self):
         chunks_matrix = self.encoder._chunkify_data(self.data)
-        row_polynomials, row_commitments = zip(*self.encoder._compute_row_kzg_commitments(chunks_matrix))
-        h = derive_challenge(row_commitments)
-        combined_poly = compute_combined_polynomial(row_polynomials, h)
-        proofs = self.encoder._compute_combined_column_proofs(combined_poly)
-        expected_extended_columns = self.params.column_count * 2
-        self.assertEqual(len(proofs), expected_extended_columns)
+        polynomials, commitments = zip(*self.encoder._compute_column_kzg_commitments(chunks_matrix))
+        self.assertEqual(len(commitments), len(chunks_matrix[0]))
+        self.assertEqual(len(polynomials), len(chunks_matrix[0]))
+
+    def test_generate_aggregated_column_commitments(self):
+        chunks_matrix = self.encoder._chunkify_data(self.data)
+        _, column_commitments = zip(*self.encoder._compute_column_kzg_commitments(chunks_matrix))
+        poly, commitment = self.encoder._compute_aggregated_column_commitment(column_commitments)
+        self.assertIsNotNone(poly)
+        self.assertIsNotNone(commitment)
+
+    def test_generate_aggregated_column_proofs(self):
+        chunks_matrix = self.encoder._chunkify_data(self.data)
+        _, column_commitments = zip(*self.encoder._compute_column_kzg_commitments(chunks_matrix))
+        poly, _ = self.encoder._compute_aggregated_column_commitment(column_commitments)
+        proofs = self.encoder._compute_aggregated_column_proofs(poly, column_commitments)
+        self.assertEqual(len(proofs), len(column_commitments))
 
     def test_encode(self):
         from random import randbytes

--- a/da/test_full_flow.py
+++ b/da/test_full_flow.py
@@ -65,6 +65,7 @@ class TestFullFlow(TestCase):
 
         # inject mock send and await method
         self.dispersal._send_and_await_response = __send_and_await_response
+        self.dispersal.disperse(encoded_data)
         blob_id = build_blob_id(encoded_data.aggregated_column_commitment, encoded_data.row_commitments)
         blob_metadata = BlobMetadata(
             blob_id,

--- a/da/test_full_flow.py
+++ b/da/test_full_flow.py
@@ -17,19 +17,18 @@ class DAVerifierWApi:
         self.api = DAApi(self.store)
         self.verifier = DAVerifier()
 
-    def receive_blob(self, blob: DAShare):
+    def receive_blob(self, blob: DABlob):
         if self.verifier.verify(blob):
             # Warning: If aggregated col commitment and row commitment are the same,
             # the build_attestation_message method will produce the same output.
-            cert_id = build_blob_id(blob.aggregated_column_commitment, blob.rows_commitments)
-            self.store.populate(blob, cert_id)
-            return attestation
+            blob_id = build_blob_id(blob.aggregated_column_commitment, blob.rows_commitments)
+            self.store.populate(blob, blob_id)
 
-    def receive_metadata(self, vid: BlobMetadata):
+    def receive_metadata(self, blob_metadata: BlobMetadata):
         # Usually the certificate would be verifier here,
         # but we are assuming that this it is already coming from the verified block,
         # in which case all certificates had been already verified by the DA Node.
-        self.api.write(vid.blob_id, vid.metadata)
+        self.api.write(blob_metadata.blob_id, blob_metadata.metadata)
 
     def read(self, app_id, indexes) -> List[Optional[DAShare]]:
         return self.api.read(app_id, indexes)
@@ -67,14 +66,14 @@ class TestFullFlow(TestCase):
         # inject mock send and await method
         self.dispersal._send_and_await_response = __send_and_await_response
         blob_id = build_blob_id(encoded_data.aggregated_column_commitment, encoded_data.row_commitments)
-        vid = BlobMetadata(
+        blob_metadata = BlobMetadata(
             blob_id,
             Metadata(app_id, index)
         )
 
         # verifier
         for node in self.api_nodes:
-            node.receive_metadata(vid)
+            node.receive_metadata(blob_metadata)
 
         # read from api and confirm its working
         # notice that we need to sort the api_nodes by their public key to have the blobs sorted in the same fashion

--- a/da/test_full_flow.py
+++ b/da/test_full_flow.py
@@ -29,7 +29,7 @@ class DAVerifierWApi:
         # Usually the certificate would be verifier here,
         # but we are assuming that this it is already coming from the verified block,
         # in which case all certificates had been already verified by the DA Node.
-        self.api.write(blob_metadata.blob_id, blob_metadata.metadata)
+        self.api.write(vid.blob_id, vid.metadata)
 
     def read(self, app_id, indexes) -> List[Optional[DAShare]]:
         return self.api.read(app_id, indexes)
@@ -66,10 +66,9 @@ class TestFullFlow(TestCase):
 
         # inject mock send and await method
         self.dispersal._send_and_await_response = __send_and_await_response
-        certificate = self.dispersal.disperse(encoded_data)
-
+        blob_id = build_blob_id(encoded_data.aggregated_column_commitment, encoded_data.row_commitments)
         vid = BlobMetadata(
-            certificate.id(),
+            blob_id,
             Metadata(app_id, index)
         )
 
@@ -104,12 +103,12 @@ class TestFullFlow(TestCase):
         # inject mock send and await method
         self.dispersal._send_and_await_response = __send_and_await_response
         self.dispersal.disperse(encoded_data)
-        blob_id = build_blob_id(encoded_data.row_commitments)
+        blob_id = build_blob_id(encoded_data.aggregated_column_commitment, encoded_data.row_commitments)
 
         # Loop through each index and simulate dispersal with the same cert_id but different metadata
         for index in indexes:
             metadata = BlobMetadata(
-                certificate.id(),
+                blob_id,
                 Metadata(app_id, index)
             )
 

--- a/da/test_full_flow.py
+++ b/da/test_full_flow.py
@@ -2,9 +2,9 @@ from itertools import chain
 from unittest import TestCase
 from typing import List, Optional
 
-from da.common import NodeId, build_blob_id
-from da.api.common import DAApi, BlobMetadata, Metadata
-from da.verifier import DAVerifier, DAShare
+from da.common import NodeId, build_blob_id, BLSPublicKey, NomosDaG2ProofOfPossession as bls_pop
+from da.api.common import DAApi, VID, Metadata
+from da.verifier import DAVerifier, DABlob 
 from da.api.test_flow import MockStore
 from da.dispersal import Dispersal, DispersalSettings
 from da.test_encoder import TestEncoder
@@ -21,8 +21,9 @@ class DAVerifierWApi:
         if self.verifier.verify(blob):
             # Warning: If aggregated col commitment and row commitment are the same,
             # the build_attestation_message method will produce the same output.
-            blob_id = build_blob_id(blob.row_commitments)
-            self.store.populate(blob, blob_id)
+            cert_id = build_blob_id(blob.aggregated_column_commitment, blob.rows_commitments)
+            self.store.populate(blob, cert_id)
+            return attestation
 
     def receive_metadata(self, blob_metadata: BlobMetadata):
         # Usually the certificate would be verifier here,

--- a/da/test_verifier.py
+++ b/da/test_verifier.py
@@ -13,6 +13,18 @@ class TestVerifier(TestCase):
     def setUp(self):
         self.verifier = DAVerifier()
 
+    def test_verify_column(self):
+        column = Column(int.to_bytes(i, length=32) for i in range(8))
+        _, column_commitment = kzg.bytes_to_commitment(column.as_bytes(), GLOBAL_PARAMETERS)
+        aggregated_poly, aggregated_column_commitment = kzg.bytes_to_commitment(
+            DAEncoder.hash_commitment_blake2b31(column_commitment), GLOBAL_PARAMETERS
+        )
+        aggregated_proof = kzg.generate_element_proof(0, aggregated_poly, GLOBAL_PARAMETERS, ROOTS_OF_UNITY)
+        self.assertTrue(
+            self.verifier._verify_column(
+                column, column_commitment, aggregated_column_commitment, aggregated_proof, 0
+            )
+        )
 
     def test_verify(self):
         _ = TestEncoder()

--- a/da/test_verifier.py
+++ b/da/test_verifier.py
@@ -35,7 +35,9 @@ class TestVerifier(TestCase):
             da_blob = DABlob(
                 Column(column),
                 i,
-                encoded_data.combined_column_proofs[i],
+                encoded_data.column_commitments[i],
+                encoded_data.aggregated_column_commitment,
+                encoded_data.aggregated_column_proofs[i],
                 encoded_data.row_commitments,
             )
             self.assertIsNotNone(verifier.verify(da_blob))
@@ -49,7 +51,9 @@ class TestVerifier(TestCase):
         da_blob = DAShare(
             Column(column),
             i,
-            encoded_data.combined_column_proofs[i],
+            encoded_data.column_commitments[i],
+            encoded_data.aggregated_column_commitment,
+            encoded_data.aggregated_column_proofs[i],
             encoded_data.row_commitments,
         )
         self.assertIsNotNone(self.verifier.verify(da_blob))
@@ -57,7 +61,9 @@ class TestVerifier(TestCase):
             da_blob = DAShare(
                 Column(column),
                 i,
-                encoded_data.combined_column_proofs[i],
+                encoded_data.column_commitments[i],
+                encoded_data.aggregated_column_commitment,
+                encoded_data.aggregated_column_proofs[i],
                 encoded_data.row_commitments,
             )
             self.assertFalse(self.verifier.verify(da_blob))

--- a/da/test_verifier.py
+++ b/da/test_verifier.py
@@ -22,7 +22,7 @@ class TestVerifier(TestCase):
         aggregated_proof = kzg.generate_element_proof(0, aggregated_poly, GLOBAL_PARAMETERS, ROOTS_OF_UNITY)
         self.assertTrue(
             self.verifier._verify_column(
-                column, column_commitment, aggregated_column_commitment, aggregated_proof, 0
+                column, 0, column_commitment, aggregated_column_commitment, aggregated_proof,
             )
         )
 
@@ -30,9 +30,9 @@ class TestVerifier(TestCase):
         _ = TestEncoder()
         _.setUp()
         encoded_data = _.encoder.encode(_.data)
-        for i, column in enumerate(encoded_data.extended_matrix.columns):
+        for i, column in enumerate(encoded_data.chunked_data.columns):
             verifier = DAVerifier()
-            da_blob = DAShare(
+            da_blob = DABlob(
                 Column(column),
                 i,
                 encoded_data.combined_column_proofs[i],
@@ -60,4 +60,4 @@ class TestVerifier(TestCase):
                 encoded_data.combined_column_proofs[i],
                 encoded_data.row_commitments,
             )
-            self.assertIsNotNone(self.verifier.verify(da_blob))
+            self.assertFalse(self.verifier.verify(da_blob))

--- a/da/test_verifier.py
+++ b/da/test_verifier.py
@@ -5,7 +5,7 @@ from da.encoder import DAEncoder
 from da.kzg_rs import kzg
 from da.kzg_rs.common import GLOBAL_PARAMETERS, ROOTS_OF_UNITY
 from da.test_encoder import TestEncoder
-from da.verifier import DAVerifier, DAShare
+from da.verifier import DAVerifier, DABlob
 
 
 class TestVerifier(TestCase):

--- a/da/verifier.py
+++ b/da/verifier.py
@@ -7,7 +7,7 @@ from eth2spec.eip7594.mainnet import (
 )
 
 import da.common
-from da.common import Column, Chunk, Attestation, BlobId, BLSPublicKey, NomosDaG2ProofOfPossession as bls_pop
+from da.common import Column, Chunk, BlobId
 from da.encoder import DAEncoder
 from da.kzg_rs import kzg
 from da.kzg_rs.bdfg_proving import combine_commitments, derive_challenge, compute_combined_evaluation

--- a/da/verifier.py
+++ b/da/verifier.py
@@ -1,5 +1,6 @@
 from dataclasses import dataclass
-from typing import List
+from hashlib import sha3_256
+from typing import List, Sequence, Set
 
 from eth2spec.eip7594.mainnet import (
     KZGCommitment as Commitment,


### PR DESCRIPTION
Implemented state aware subnetworks filling algorithm.

The algorithm works as follows:
1. Remove nodes that are not active from the previous subnetworks assignations
2. Get all active nodes ordered by, primary the number of subnetworks each participant is at and secondary by the `DeclarationId` of the participant (ascending order).
3. Get all subnetworks ordered by the number of participants in each subnetwork
4. Until all subnetworks are filled up to replication factor and all nodes are assigned:
    1. Select the subnetwork with the least participants
    2. Select the participant with less participation
    3. Add the participant into the subnetwork and increment its participation count
    4. Add the participant and the subnetwork into the respective collections and reorder them based on ordering hints in step 2 and 3
5. Return the subnetworks ordered by its subnetwork id