### PR TITLE
feat: Implement subnetworks assignations algorithm

### DIFF
--- a/da/assignations/refill.py
+++ b/da/assignations/refill.py
@@ -1,5 +1,7 @@
+import contextlib
+import random
 from dataclasses import dataclass
-from typing import List, Set, TypeAlias, Sequence
+from typing import List, Set, TypeAlias, Sequence, Any
 from itertools import cycle, chain
 from collections import Counter
 from heapq import heappush, heappop, heapify
@@ -7,6 +9,11 @@ from heapq import heappush, heappop, heapify
 
 DeclarationId:  TypeAlias = bytes
 Assignations: TypeAlias = List[Set[DeclarationId]]
+ChaCha20: TypeAlias = Any
+
+# add randomnees seed
+# add random picks on balance
+# remove peers on growing networks
 
 
 @dataclass(order=True)
@@ -78,23 +85,31 @@ def fill_subnetworks(
 
 def balance_subnetworks(
         subnetworks: List[Subnetwork],
+        random: ChaCha20,
 ):
     while (len(max(subnetworks)) - len(min(subnetworks))) > 1:
         max_subnetwork = max(subnetworks)
         min_subnetwork = min(subnetworks)
         diff_count = (len(max_subnetwork.participants) - len(min_subnetwork.participants)) // 2
         diff_participants = sorted(max_subnetwork.participants - min_subnetwork.participants)
-        for i in range(diff_count):
-            move_participant = diff_participants.pop(0)
-            min_subnetwork.participants.add(move_participant)
-            max_subnetwork.participants.remove(move_participant)
+        for participant in random.sample(diff_participants, k=diff_count):
+            min_subnetwork.participants.add(participant)
+            max_subnetwork.participants.remove(participant)
     heapify(subnetworks)
+
+@contextlib.contextmanager
+def rand(seed: bytes):
+    prev_rand = random.getstate()
+    random.seed(seed)
+    yield random
+    random.setstate(prev_rand)
 
 
 def calculate_subnetwork_assignations(
         new_nodes_list: Sequence[DeclarationId],
         previous_subnets: Assignations,
-        replication_factor: int
+        replication_factor: int,
+        random_seed: bytes,
 ) -> Assignations:
     # The algorithm works as follows:
     # 1. Remove nodes that are not active from the previous subnetworks assignations
@@ -103,7 +118,8 @@ def calculate_subnetwork_assignations(
     # 3. Create a heap with the subnetworks ordered by the number of participants in each subnetwork
     # 4. If the network is decreasing (less available nodes than previous nodes), balance subnetworks:
     #    1) Until the biggest subnetwork and the smallest subnetwork size difference is <= 1
-    #    2) Pick the biggest subnetwork and migrate half of the node difference to the smallest subnetwork
+    #    2) Pick the biggest subnetwork and migrate half of the node difference to the smallest subnetwork,
+    #       randomly choosing them.
     # 5. Until all subnetworks are filled up to a replication factor and all nodes are assigned:
     #    1) pop the subnetwork with the fewest participants
     #    2) pop the participant with less participation
@@ -111,39 +127,41 @@ def calculate_subnetwork_assignations(
     #    4) push the participant and the subnetwork into the respective heaps
     # 6. Return the subnetworks ordered by its subnetwork id
 
-    # average participation per node
-    average_participation = max((len(previous_subnets) * replication_factor) // len(new_nodes_list), 1)
+    # initialize randomness
+    with rand(random_seed) as random:
+        # average participation per node
+        average_participation = max((len(previous_subnets) * replication_factor) // len(new_nodes_list), 1)
 
-    # prepare sets
-    previous_nodes = set(chain.from_iterable(previous_subnets))
-    new_nodes = set(new_nodes_list)
-    unavailable_nodes = previous_nodes - new_nodes
+        # prepare sets
+        previous_nodes = set(chain.from_iterable(previous_subnets))
+        new_nodes = set(new_nodes_list)
+        unavailable_nodes = previous_nodes - new_nodes
 
-    # remove unavailable nodes
-    active_assignations = [subnet - unavailable_nodes for subnet in previous_subnets]
+        # remove unavailable nodes
+        active_assignations = [subnet - unavailable_nodes for subnet in previous_subnets]
 
-    # count participation per assigned node
-    assigned_count: Counter[DeclarationId] = Counter(chain.from_iterable(active_assignations))
+        # count participation per assigned node
+        assigned_count: Counter[DeclarationId] = Counter(chain.from_iterable(active_assignations))
 
-    # available nodes heap
-    available_nodes = [
-        Participant(participation=assigned_count.get(_id, 0), declaration_id=_id) for _id in new_nodes
-    ]
-    heapify(available_nodes)
+        # available nodes heap
+        available_nodes = [
+            Participant(participation=assigned_count.get(_id, 0), declaration_id=_id) for _id in new_nodes
+        ]
+        heapify(available_nodes)
 
-    # subnetworks heap
-    subnetworks = list(
-        Subnetwork(participants=subnet, subnetwork_id=subnetwork_id)
-        for subnetwork_id, subnet in enumerate(active_assignations)
-    )
-    heapify(subnetworks)
+        # subnetworks heap
+        subnetworks = list(
+            Subnetwork(participants=subnet, subnetwork_id=subnetwork_id)
+            for subnetwork_id, subnet in enumerate(active_assignations)
+        )
+        heapify(subnetworks)
 
-    # when shrinking, the network diversifies nodes in major subnetworks into emptier ones
-    if len(previous_nodes) > len(new_nodes):
-        balance_subnetworks(subnetworks)
+        # when shrinking, the network diversifies nodes in major subnetworks into emptier ones
+        if len(previous_nodes) > len(new_nodes):
+            balance_subnetworks(subnetworks, random)
 
-    # this method mutates the subnetworks
-    fill_subnetworks(available_nodes, subnetworks, average_participation, replication_factor)
+        # this method mutates the subnetworks
+        fill_subnetworks(available_nodes, subnetworks, average_participation, replication_factor)
 
-    return [subnetwork.participants for subnetwork in sorted(subnetworks, key=lambda x: x.subnetwork_id)]
+        return [subnetwork.participants for subnetwork in sorted(subnetworks, key=lambda x: x.subnetwork_id)]
 

--- a/da/assignations/refill.py
+++ b/da/assignations/refill.py
@@ -1,0 +1,127 @@
+from dataclasses import dataclass
+from typing import List, Set, TypeAlias, Sequence
+from itertools import cycle, chain
+from collections import Counter
+from heapq import heappush, heappop, heapify
+
+DeclarationId:  TypeAlias = bytes
+Assignations: TypeAlias = List[Set[DeclarationId]]
+
+@dataclass(order=True)
+class Participant:
+    # Participants wrapper class
+    # Used for keeping ordering in the heap by the participation first and the declaration id second
+    participation: int              # prioritize participation count first
+    declaration_id: DeclarationId   # sort by id on default
+
+@dataclass
+class Subnetwork:
+    # Subnetwork wrapper that keeps the subnetwork id [0..2048) and the set of participants in that subnetwork
+    participants: Set[DeclarationId]
+    subnetwork_id: int
+
+    def __lt__(self, other):
+        return len(self) < len(other)
+
+    def __len__(self):
+        return len(self.participants)
+
+
+
+def are_subnetworks_filled_up_to_replication_factor(subnetworks: Sequence[Subnetwork], replication_factor: int) -> bool:
+    return all(len(subnetwork) >= replication_factor for subnetwork in subnetworks)
+
+def all_nodes_are_assigned(participants: Sequence[Participant]) -> bool:
+    return all(participant.participation > 0 for participant in participants)
+
+
+def heappop_next_for_participant(subnetworks: List[Subnetwork], participant: Participant) -> Subnetwork:
+    filtered = [subnetwork for subnetwork in subnetworks if participant.declaration_id not in subnetwork.participants]
+    poped = heappop(filtered)
+    subnetworks.remove(poped)
+    heapify(subnetworks)
+    return poped
+
+def calculate_subnetwork_assignations(
+        new_nodes_list: Sequence[DeclarationId],
+        previous_subnets: Assignations,
+        replication_factor: int
+) -> Assignations:
+    # The algorithm works as follows:
+    # 1. Remove nodes that are not active from the previous subnetworks assignations
+    # 2. Create a heap with the set of active nodes ordered by, primary the number of subnetworks each participant is at
+    #    and secondary by the DeclarationId of the participant (ascending order).
+    # 3. Create a heap with the subnetworks ordered by the number of participants in each subnetwork
+    # 4. Until all subnetworks are filled up to replication factor and all nodes are assigned:
+    #    1) pop the subnetwork with the least participants
+    #    2) pop the participant with less participations
+    #    3) push the participant into the subnetwork and increment its participation count
+    #    4) push the participant and the subnetwork into the respective heaps
+    # 5. Return the subnetworks ordered by its subnetwork id
+
+    # prepare sets
+    previous_nodes =  set(chain.from_iterable(previous_subnets))
+    new_nodes = set(new_nodes_list)
+    unavailable_nodes = previous_nodes - new_nodes
+
+    # remove unavailable nodes
+    active_assignations = [subnet - unavailable_nodes for subnet in previous_subnets]
+
+    # count participation per assigned node
+    assigned_count: Counter[DeclarationId] = Counter(chain.from_iterable(active_assignations))
+
+    # available nodes heap
+    available_nodes = [
+        Participant(participation=assigned_count.get(_id, 0), declaration_id=_id) for _id in new_nodes
+    ]
+    heapify(available_nodes)
+
+    # subnetworks heap
+    subnetworks = list(
+        Subnetwork(participants=subnet, subnetwork_id=subnetwork_id)
+        for subnetwork_id, subnet in enumerate(active_assignations)
+    )
+    heapify(subnetworks)
+
+
+    while not (
+        are_subnetworks_filled_up_to_replication_factor(subnetworks, replication_factor) and
+        all_nodes_are_assigned(available_nodes)
+    ):
+        # take less participations declaration
+        participant = heappop(available_nodes)
+
+        # take less participants subnetwork
+        subnetwork = heappop(subnetworks)
+
+        # fill into subnetwork
+        subnetwork.participants.add(participant.declaration_id)
+        participant.participation += 1
+        # push to queues
+        heappush(available_nodes, participant)
+        heappush(subnetworks, subnetwork)
+    return [subnetwork.participants for subnetwork in sorted(subnetworks, key=lambda x: x.subnetwork_id)]
+
+
+
+
+if __name__ == "__main__":
+    import random
+    number_of_columns = 4096
+    for size in [100, 500, 1000, 10000]:
+        nodes_ids = [random.randbytes(32) for _ in range(size)]
+        replication_factor = 3
+        print(size, replication_factor)
+        # print(a := calculate_subnets(nodes_ids, number_of_columns, replication_factor))
+        from pprint import pprint
+        b = calculate_subnetwork_assignations(nodes_ids, [set() for _ in range(number_of_columns)], replication_factor)
+        # pprint(b)
+        assert len(set(chain.from_iterable(b))) == len(nodes_ids)
+        # fill up new nodes
+        for i in range(0, size, 5):
+            nodes_ids[i] = random.randbytes(32)
+        b = calculate_subnetwork_assignations(nodes_ids, b, replication_factor)
+        # pprint(b)
+        assert len(set(chain.from_iterable(b))) == len(nodes_ids), f"{len(set(chain.from_iterable(b)))} != {len(nodes_ids)}"
+        print(Counter(chain.from_iterable(b)).values())
+

--- a/da/assignations/refill.py
+++ b/da/assignations/refill.py
@@ -49,6 +49,44 @@ def heappop_next_for_subnetwork(subnetwork: Subnetwork, participants: List[Parti
         heappush(participants, poped)
     return participant
 
+def fill_subnetworks(
+        available_nodes: List[Participant],
+        subnetworks: List[Subnetwork],
+        average_participation: int,
+        replication_factor: int,
+):
+    while not (
+            are_subnetworks_filled_up_to_replication_factor(subnetworks, replication_factor) and
+            all_nodes_are_assigned(available_nodes, average_participation)
+    ):
+        # take less participants subnetwork
+        subnetwork = heappop(subnetworks)
+
+        # take less participations declaration not included in the subnetwork
+        participant = heappop_next_for_subnetwork(subnetwork, available_nodes)
+
+        # fill into subnetwork
+        subnetwork.participants.add(participant.declaration_id)
+        participant.participation += 1
+        # push to heaps
+        heappush(available_nodes, participant)
+        heappush(subnetworks, subnetwork)
+
+
+def balance_subnetworks(
+        subnetworks: List[Subnetwork],
+):
+    while (len(max(subnetworks)) - len(min(subnetworks))) > 1:
+        max_subnetwork = max(subnetworks)
+        min_subnetwork = min(subnetworks)
+        diff_count = (len(max_subnetwork.participants) - len(min_subnetwork.participants)) // 2
+        diff_participants = sorted(max_subnetwork.participants - min_subnetwork.participants)
+        for i in range(diff_count):
+            move_participant = diff_participants.pop(0)
+            min_subnetwork.participants.add(move_participant)
+            max_subnetwork.participants.remove(move_participant)
+    heapify(subnetworks)
+
 def calculate_subnetwork_assignations(
         new_nodes_list: Sequence[DeclarationId],
         previous_subnets: Assignations,
@@ -105,41 +143,3 @@ def calculate_subnetwork_assignations(
 
     return [subnetwork.participants for subnetwork in sorted(subnetworks, key=lambda x: x.subnetwork_id)]
 
-
-def fill_subnetworks(
-        available_nodes: List[Participant],
-        subnetworks: List[Subnetwork],
-        average_participation: int,
-        replication_factor: int,
-):
-    while not (
-            are_subnetworks_filled_up_to_replication_factor(subnetworks, replication_factor) and
-            all_nodes_are_assigned(available_nodes, average_participation)
-    ):
-        # take less participants subnetwork
-        subnetwork = heappop(subnetworks)
-
-        # take less participations declaration not included in the subnetwork
-        participant = heappop_next_for_subnetwork(subnetwork, available_nodes)
-
-        # fill into subnetwork
-        subnetwork.participants.add(participant.declaration_id)
-        participant.participation += 1
-        # push to heaps
-        heappush(available_nodes, participant)
-        heappush(subnetworks, subnetwork)
-
-
-def balance_subnetworks(
-        subnetworks: List[Subnetwork],
-):
-    while (len(max(subnetworks)) - len(min(subnetworks))) > 1:
-        max_subnetwork = max(subnetworks)
-        min_subnetwork = min(subnetworks)
-        diff_count = (len(max_subnetwork.participants) - len(min_subnetwork.participants)) // 2
-        diff_participants = sorted(max_subnetwork.participants - min_subnetwork.participants)
-        for i in range(diff_count):
-            move_participant = diff_participants.pop(0)
-            min_subnetwork.participants.add(move_participant)
-            max_subnetwork.participants.remove(move_participant)
-    heapify(subnetworks)

--- a/da/assignations/refill.py
+++ b/da/assignations/refill.py
@@ -59,12 +59,15 @@ def calculate_subnetwork_assignations(
     # 2. Create a heap with the set of active nodes ordered by, primary the number of subnetworks each participant is at
     #    and secondary by the DeclarationId of the participant (ascending order).
     # 3. Create a heap with the subnetworks ordered by the number of participants in each subnetwork
-    # 4. Until all subnetworks are filled up to replication factor and all nodes are assigned:
+    # 4. If network is decreasing (less availabe nodes than previous nodes), balance subnetworks:
+    #    1) Until the biggest subnetwork and the smallest subnetwork size difference is <= 1
+    #    2) Pick the biggest subnetwork and migrate half of the nodes difference to the smallest subnetwork
+    # 5. Until all subnetworks are filled up to replication factor and all nodes are assigned:
     #    1) pop the subnetwork with the least participants
     #    2) pop the participant with less participations
     #    3) push the participant into the subnetwork and increment its participation count
     #    4) push the participant and the subnetwork into the respective heaps
-    # 5. Return the subnetworks ordered by its subnetwork id
+    # 6. Return the subnetworks ordered by its subnetwork id
 
     # average participation per node
     average_participation = max((len(previous_subnets) * replication_factor) // len(new_nodes_list), 1)

--- a/da/assignations/refill.py
+++ b/da/assignations/refill.py
@@ -9,7 +9,7 @@ from heapq import heappush, heappop, heapify
 
 DeclarationId:  TypeAlias = bytes
 Assignations: TypeAlias = List[Set[DeclarationId]]
-ChaCha20: TypeAlias = Any
+BlakeRng: TypeAlias = Any
 
 
 @dataclass(order=True)
@@ -36,11 +36,11 @@ class Subnetwork:
         return len(self.participants)
 
 
-def are_subnetworks_filled_up_to_replication_factor(subnetworks: Sequence[Subnetwork], replication_factor: int) -> bool:
+def subnetworks_filled_up_to_replication_factor(subnetworks: Sequence[Subnetwork], replication_factor: int) -> bool:
     return all(len(subnetwork) >= replication_factor for subnetwork in subnetworks)
 
 
-def all_nodes_are_assigned(participants: Sequence[Participant], average_participation: int) -> bool:
+def all_nodes_assigned(participants: Sequence[Participant], average_participation: int) -> bool:
     return all(participant.participation >= average_participation for participant in participants)
 
 
@@ -55,7 +55,7 @@ def heappop_next_for_subnetwork(subnetwork: Subnetwork, participants: List[Parti
     return participant
 
 # sample using fisher yates shuffling, returning
-def sample(elements: Sequence[Any], random: ChaCha20, k: int) -> List[Any]:
+def sample(elements: Sequence[Any], random: BlakeRng, k: int) -> List[Any]:
     # list is sorted for reproducibility
     elements = sorted(elements)
     # pythons built-in is fisher yates shuffling
@@ -73,8 +73,8 @@ def fill_subnetworks(
     heapify(subnetworks)
 
     while not (
-            are_subnetworks_filled_up_to_replication_factor(subnetworks, replication_factor) and
-            all_nodes_are_assigned(available_nodes, average_participation)
+            subnetworks_filled_up_to_replication_factor(subnetworks, replication_factor) and
+            all_nodes_assigned(available_nodes, average_participation)
     ):
         # take the fewest participants subnetwork
         subnetwork = heappop(subnetworks)
@@ -92,7 +92,7 @@ def fill_subnetworks(
 
 def balance_subnetworks_shrink(
         subnetworks: List[Subnetwork],
-        random: ChaCha20,
+        random: BlakeRng,
 ):
     while (len(max(subnetworks)) - len(min(subnetworks))) > 1:
         max_subnetwork = max(subnetworks)
@@ -108,7 +108,7 @@ def balance_subnetworks_grow(
         subnetworks: List[Subnetwork],
         participants: List[Participant],
         average_participation: int,
-        random: ChaCha20,
+        random: BlakeRng,
 ):
     for participant in filter(lambda x: x.participation > average_participation, sorted(participants)):
         for subnework in sample(

--- a/da/assignations/refill.py
+++ b/da/assignations/refill.py
@@ -101,27 +101,3 @@ def calculate_subnetwork_assignations(
         heappush(available_nodes, participant)
         heappush(subnetworks, subnetwork)
     return [subnetwork.participants for subnetwork in sorted(subnetworks, key=lambda x: x.subnetwork_id)]
-
-
-
-
-if __name__ == "__main__":
-    import random
-    number_of_columns = 4096
-    for size in [100, 500, 1000, 10000]:
-        nodes_ids = [random.randbytes(32) for _ in range(size)]
-        replication_factor = 3
-        print(size, replication_factor)
-        # print(a := calculate_subnets(nodes_ids, number_of_columns, replication_factor))
-        from pprint import pprint
-        b = calculate_subnetwork_assignations(nodes_ids, [set() for _ in range(number_of_columns)], replication_factor)
-        # pprint(b)
-        assert len(set(chain.from_iterable(b))) == len(nodes_ids)
-        # fill up new nodes
-        for i in range(0, size, 5):
-            nodes_ids[i] = random.randbytes(32)
-        b = calculate_subnetwork_assignations(nodes_ids, b, replication_factor)
-        # pprint(b)
-        assert len(set(chain.from_iterable(b))) == len(nodes_ids), f"{len(set(chain.from_iterable(b)))} != {len(nodes_ids)}"
-        print(Counter(chain.from_iterable(b)).values())
-

--- a/da/assignations/refill.py
+++ b/da/assignations/refill.py
@@ -54,6 +54,14 @@ def heappop_next_for_subnetwork(subnetwork: Subnetwork, participants: List[Parti
         heappush(participants, poped)
     return participant
 
+# sample using fisher yates shuffling, returning
+def sample(elements: Sequence[Any], random: ChaCha20, k: int) -> List[Any]:
+    # list is sorted for reproducibility
+    elements = sorted(elements)
+    # pythons built-in is fisher yates shuffling
+    random.shuffle(elements)
+    return elements[:k]
+
 
 def fill_subnetworks(
         available_nodes: List[Participant],
@@ -91,7 +99,7 @@ def balance_subnetworks_shrink(
         min_subnetwork = min(subnetworks)
         diff_count = (len(max_subnetwork.participants) - len(min_subnetwork.participants)) // 2
         diff_participants = sorted(max_subnetwork.participants - min_subnetwork.participants)
-        for participant in random.sample(diff_participants, k=diff_count):
+        for participant in sample(diff_participants, random, k=diff_count):
             min_subnetwork.participants.add(participant)
             max_subnetwork.participants.remove(participant)
 
@@ -103,8 +111,9 @@ def balance_subnetworks_grow(
         random: ChaCha20,
 ):
     for participant in filter(lambda x: x.participation > average_participation, sorted(participants)):
-        for subnework in random.sample(
+        for subnework in sample(
                 sorted(filter(lambda subnetwork: participant.declaration_id in subnetwork.participants, subnetworks)),
+                random,
                 k=participant.participation - average_participation
         ):
             subnework.participants.remove(participant.declaration_id)

--- a/da/assignations/refill.py
+++ b/da/assignations/refill.py
@@ -134,6 +134,8 @@ def calculate_subnetwork_assignations(
         replication_factor: int,
         random_seed: bytes,
 ) -> Assignations:
+    if len(new_nodes_list) < replication_factor:
+        raise ValueError("The network size is smaller than the replication factor")
     # The algorithm works as follows:
     # 1. Remove nodes that are not active from the previous subnetworks assignations
     # 2. If the network is decreasing (less available nodes than previous nodes), balance subnetworks:

--- a/da/assignations/refill.py
+++ b/da/assignations/refill.py
@@ -62,10 +62,10 @@ def fill_subnetworks(
             are_subnetworks_filled_up_to_replication_factor(subnetworks, replication_factor) and
             all_nodes_are_assigned(available_nodes, average_participation)
     ):
-        # take fewer participants subnetwork
+        # take the fewest participants subnetwork
         subnetwork = heappop(subnetworks)
 
-        # take less participation declaration not included in the subnetwork
+        # take the declaration with the lowest participation that is not included in the subnetwork
         participant = heappop_next_for_subnetwork(subnetwork, available_nodes)
 
         # fill into subnetwork

--- a/da/assignations/refill.py
+++ b/da/assignations/refill.py
@@ -4,17 +4,18 @@ from itertools import cycle, chain
 from collections import Counter
 from heapq import heappush, heappop, heapify
 
-from numpy.f2py.crackfortran import previous_context
 
 DeclarationId:  TypeAlias = bytes
 Assignations: TypeAlias = List[Set[DeclarationId]]
 
+
 @dataclass(order=True)
 class Participant:
-    # Participants wrapper class
+    # Participant's wrapper class
     # Used for keeping ordering in the heap by the participation first and the declaration id second
     participation: int              # prioritize participation count first
     declaration_id: DeclarationId   # sort by id on default
+
 
 @dataclass
 class Subnetwork:
@@ -35,6 +36,7 @@ class Subnetwork:
 def are_subnetworks_filled_up_to_replication_factor(subnetworks: Sequence[Subnetwork], replication_factor: int) -> bool:
     return all(len(subnetwork) >= replication_factor for subnetwork in subnetworks)
 
+
 def all_nodes_are_assigned(participants: Sequence[Participant], average_participation: int) -> bool:
     return all(participant.participation > average_participation for participant in participants)
 
@@ -49,6 +51,7 @@ def heappop_next_for_subnetwork(subnetwork: Subnetwork, participants: List[Parti
         heappush(participants, poped)
     return participant
 
+
 def fill_subnetworks(
         available_nodes: List[Participant],
         subnetworks: List[Subnetwork],
@@ -59,10 +62,10 @@ def fill_subnetworks(
             are_subnetworks_filled_up_to_replication_factor(subnetworks, replication_factor) and
             all_nodes_are_assigned(available_nodes, average_participation)
     ):
-        # take less participants subnetwork
+        # take fewer participants subnetwork
         subnetwork = heappop(subnetworks)
 
-        # take less participations declaration not included in the subnetwork
+        # take less participation declaration not included in the subnetwork
         participant = heappop_next_for_subnetwork(subnetwork, available_nodes)
 
         # fill into subnetwork
@@ -87,6 +90,7 @@ def balance_subnetworks(
             max_subnetwork.participants.remove(move_participant)
     heapify(subnetworks)
 
+
 def calculate_subnetwork_assignations(
         new_nodes_list: Sequence[DeclarationId],
         previous_subnets: Assignations,
@@ -97,12 +101,12 @@ def calculate_subnetwork_assignations(
     # 2. Create a heap with the set of active nodes ordered by, primary the number of subnetworks each participant is at
     #    and secondary by the DeclarationId of the participant (ascending order).
     # 3. Create a heap with the subnetworks ordered by the number of participants in each subnetwork
-    # 4. If network is decreasing (less availabe nodes than previous nodes), balance subnetworks:
+    # 4. If the network is decreasing (less available nodes than previous nodes), balance subnetworks:
     #    1) Until the biggest subnetwork and the smallest subnetwork size difference is <= 1
-    #    2) Pick the biggest subnetwork and migrate half of the nodes difference to the smallest subnetwork
-    # 5. Until all subnetworks are filled up to replication factor and all nodes are assigned:
-    #    1) pop the subnetwork with the least participants
-    #    2) pop the participant with less participations
+    #    2) Pick the biggest subnetwork and migrate half of the node difference to the smallest subnetwork
+    # 5. Until all subnetworks are filled up to a replication factor and all nodes are assigned:
+    #    1) pop the subnetwork with the fewest participants
+    #    2) pop the participant with less participation
     #    3) push the participant into the subnetwork and increment its participation count
     #    4) push the participant and the subnetwork into the respective heaps
     # 6. Return the subnetworks ordered by its subnetwork id
@@ -134,7 +138,7 @@ def calculate_subnetwork_assignations(
     )
     heapify(subnetworks)
 
-    # when shrinking the network diversify nodes in major subnetworks into emptier ones
+    # when shrinking, the network diversifies nodes in major subnetworks into emptier ones
     if len(previous_nodes) > len(new_nodes):
         balance_subnetworks(subnetworks)
 

--- a/da/assignations/test_refill.py
+++ b/da/assignations/test_refill.py
@@ -1,6 +1,6 @@
 import random
 from itertools import chain
-from typing import List
+from typing import List, Counter
 from unittest import TestCase
 from da.assignations.refill import calculate_subnetwork_assignations, Assignations, DeclarationId
 
@@ -101,5 +101,10 @@ class TestRefill(TestCase):
             msg="Subnetwork size variant should not be bigger than 1",
             delta=1
         )
-        # add assert on balance participation per node
+        self.assertAlmostEqual(
+            len(set(Counter(chain.from_iterable(assignations)).values())),
+            1,
+            msg="Nodes should be assigned uniformly to subnetworks",
+            delta=1,
+        )
 

--- a/da/assignations/test_refill.py
+++ b/da/assignations/test_refill.py
@@ -23,8 +23,9 @@ class TestRefill(TestCase):
         nodes = [random.randbytes(32) for _ in range(network_size)]
         assignations = [set() for _ in range(2048)]
         assignations = calculate_subnetwork_assignations(nodes, assignations, replication_factor)
+        new_nodes = nodes
         for network_size in [300, 500, 1000, 10000, 100000]:
-            new_nodes = self.expand_nodes(nodes, network_size - len(nodes))
+            new_nodes = self.expand_nodes(new_nodes, network_size - len(nodes))
             self.mutate_nodes(new_nodes, network_size//3)
             assignations = calculate_subnetwork_assignations(new_nodes, assignations, replication_factor)
             self.assert_assignations(assignations, new_nodes, replication_factor)
@@ -35,11 +36,32 @@ class TestRefill(TestCase):
         nodes = [random.randbytes(32) for _ in range(network_size)]
         assignations = [set() for _ in range(2048)]
         assignations = calculate_subnetwork_assignations(nodes, assignations, replication_factor)
+        new_nodes = nodes
         for network_size in reversed([100, 300, 500, 1000, 10000]):
-            new_nodes = self.shrink_nodes(nodes, network_size)
+            new_nodes = self.shrink_nodes(new_nodes, network_size)
             self.mutate_nodes(new_nodes, network_size//3)
             assignations = calculate_subnetwork_assignations(new_nodes, assignations, replication_factor)
             self.assert_assignations(assignations, new_nodes, replication_factor)
+
+
+    def test_random_increase_decrease_network(self):
+        network_size = 10000
+        replication_factor = 3
+        nodes = [random.randbytes(32) for _ in range(network_size)]
+        assignations = [set() for _ in range(2048)]
+        assignations = calculate_subnetwork_assignations(nodes, assignations, replication_factor)
+        new_nodes = nodes
+        for step in (random.randrange(100, 1000) for _ in range(100)):
+            if bool(random.choice((0, 1))):
+                network_size += step
+                new_nodes = self.expand_nodes(new_nodes, network_size)
+            else:
+                network_size -= step
+                new_nodes = self.shrink_nodes(new_nodes, network_size)
+            self.mutate_nodes(new_nodes, network_size//3)
+            assignations = calculate_subnetwork_assignations(new_nodes, assignations, replication_factor)
+            self.assert_assignations(assignations, new_nodes, replication_factor)
+
 
     @classmethod
     def mutate_nodes(cls, nodes: List[DeclarationId], count: int):

--- a/da/assignations/test_refill.py
+++ b/da/assignations/test_refill.py
@@ -7,9 +7,10 @@ from da.assignations.refill import calculate_subnetwork_assignations, Assignatio
 
 class TestRefill(TestCase):
     def test_single_with(self, subnetworks_size = 2048, replication_factor: int = 3, network_size: int = 100):
+        random_seed = random.randbytes(32)
         nodes = [random.randbytes(32) for _ in range(network_size)]
         previous_nodes = [set() for _ in range(subnetworks_size)]
-        assignations = calculate_subnetwork_assignations(nodes, previous_nodes, replication_factor)
+        assignations = calculate_subnetwork_assignations(nodes, previous_nodes, replication_factor, random_seed)
         self.assert_assignations(assignations, nodes, replication_factor)
 
     def test_single_network_sizes(self):
@@ -18,40 +19,46 @@ class TestRefill(TestCase):
                 self.test_single_with(network_size=i)
 
     def test_evolving_increasing_network(self):
+        random_seed = random.randbytes(32)
         network_size = 100
         replication_factor = 3
         nodes = [random.randbytes(32) for _ in range(network_size)]
         assignations = [set() for _ in range(2048)]
-        assignations = calculate_subnetwork_assignations(nodes, assignations, replication_factor)
+        assignations = calculate_subnetwork_assignations(nodes, assignations, replication_factor, random_seed)
         new_nodes = nodes
         for network_size in [300, 500, 1000, 10000, 100000]:
+            random_seed = random.randbytes(32)
             new_nodes = self.expand_nodes(new_nodes, network_size - len(nodes))
             self.mutate_nodes(new_nodes, network_size//3)
-            assignations = calculate_subnetwork_assignations(new_nodes, assignations, replication_factor)
+            assignations = calculate_subnetwork_assignations(new_nodes, assignations, replication_factor, random_seed)
             self.assert_assignations(assignations, new_nodes, replication_factor)
 
     def test_evolving_decreasing_network(self):
+        random_seed = random.randbytes(32)
         network_size = 100000
         replication_factor = 3
         nodes = [random.randbytes(32) for _ in range(network_size)]
         assignations = [set() for _ in range(2048)]
-        assignations = calculate_subnetwork_assignations(nodes, assignations, replication_factor)
+        assignations = calculate_subnetwork_assignations(nodes, assignations, replication_factor, random_seed)
         new_nodes = nodes
         for network_size in reversed([100, 300, 500, 1000, 10000]):
+            random_seed = random.randbytes(32)
             new_nodes = self.shrink_nodes(new_nodes, network_size)
             self.mutate_nodes(new_nodes, network_size//3)
-            assignations = calculate_subnetwork_assignations(new_nodes, assignations, replication_factor)
+            assignations = calculate_subnetwork_assignations(new_nodes, assignations, replication_factor, random_seed)
             self.assert_assignations(assignations, new_nodes, replication_factor)
 
 
     def test_random_increase_decrease_network(self):
+        random_seed = random.randbytes(32)
         network_size = 10000
         replication_factor = 3
         nodes = [random.randbytes(32) for _ in range(network_size)]
         assignations = [set() for _ in range(2048)]
-        assignations = calculate_subnetwork_assignations(nodes, assignations, replication_factor)
+        assignations = calculate_subnetwork_assignations(nodes, assignations, replication_factor, random_seed)
         new_nodes = nodes
         for step in (random.randrange(100, 1000) for _ in range(100)):
+            random_seed = random.randbytes(32)
             if bool(random.choice((0, 1))):
                 network_size += step
                 new_nodes = self.expand_nodes(new_nodes, network_size)
@@ -59,7 +66,7 @@ class TestRefill(TestCase):
                 network_size -= step
                 new_nodes = self.shrink_nodes(new_nodes, network_size)
             self.mutate_nodes(new_nodes, network_size//3)
-            assignations = calculate_subnetwork_assignations(new_nodes, assignations, replication_factor)
+            assignations = calculate_subnetwork_assignations(new_nodes, assignations, replication_factor, random_seed)
             self.assert_assignations(assignations, new_nodes, replication_factor)
 
 
@@ -94,4 +101,5 @@ class TestRefill(TestCase):
             msg="Subnetwork size variant should not be bigger than 1",
             delta=1
         )
+        # add assert on balance participation per node
 

--- a/da/assignations/test_refill.py
+++ b/da/assignations/test_refill.py
@@ -1,0 +1,59 @@
+import random
+from itertools import chain
+from typing import List
+from unittest import TestCase
+from da.assignations.refill import calculate_subnetwork_assignations, Assignations, DeclarationId
+
+
+class TestRefill(TestCase):
+    def test_single_with(self, subnetworks_size = 2048, replication_factor: int = 3, network_size: int = 100):
+        nodes = [random.randbytes(32) for _ in range(network_size)]
+        previous_nodes = [set() for _ in range(subnetworks_size)]
+        assignations = calculate_subnetwork_assignations(nodes, previous_nodes, replication_factor)
+        self.assert_assignations(assignations, nodes, replication_factor)
+
+    def test_single_network_sizes(self):
+        for i in [500, 1000, 10000, 100000]:
+            with self.subTest(i):
+                self.test_single_with(network_size=i)
+
+    def test_same_sized_evolving_network(self):
+        network_size = 100
+        replication_factor = 3
+        nodes = [random.randbytes(32) for _ in range(network_size)]
+        assignations = [set() for _ in range(network_size)]
+        assignations = calculate_subnetwork_assignations(nodes, assignations, replication_factor)
+        for network_size in [300, 500, 1000, 10000, 100000]:
+            new_nodes = self.expand_nodes(nodes, network_size)
+            self.mutate_nodes(new_nodes, network_size//3)
+            assignations = calculate_subnetwork_assignations(new_nodes, assignations, replication_factor)
+            self.assert_assignations(assignations, new_nodes, replication_factor)
+
+    @classmethod
+    def mutate_nodes(cls, nodes: List[DeclarationId], count: int):
+        assert count < len(nodes)
+        for i in random.choices(list(range(len(nodes))), k=count):
+            nodes[i] = random.randbytes(32)
+
+    @classmethod
+    def expand_nodes(cls, nodes: List[DeclarationId], count: int) -> List[DeclarationId]:
+        return [*nodes, *(random.randbytes(32) for _ in range(count))]
+
+
+    def assert_assignations(self, assignations: Assignations, nodes: List[DeclarationId], replication_factor: int):
+        self.assertEqual(
+            len(set(chain.from_iterable(assignations))),
+            len(nodes),
+            "Only active nodes should be assigned"
+        )
+        self.assertTrue(
+            all(len(assignation) >= replication_factor for assignation in assignations),
+            f"No subnetworks should have less than {replication_factor} nodes"
+        )
+        self.assertAlmostEqual(
+            max(map(len, assignations)),
+            min(map(len, assignations)),
+            msg="Subnetwork size variant should not be bigger than 1",
+            delta=1
+        )
+


### PR DESCRIPTION
Implemented state aware subnetworks filling algorithm.

The algorithm works as follows:
1. Remove nodes that are not active from the previous subnetworks assignations
2. Get all active nodes ordered by, primary the number of subnetworks each participant is at and secondary by the `DeclarationId` of the participant (ascending order).
3. Get all subnetworks ordered by the number of participants in each subnetwork
4. Until all subnetworks are filled up to replication factor and all nodes are assigned:
    1. Select the subnetwork with the least participants
    2. Select the participant with less participation
    3. Add the participant into the subnetwork and increment its participation count
    4. Add the participant and the subnetwork into the respective collections and reorder them based on ordering hints in step 2 and 3
5. Return the subnetworks ordered by its subnetwork id